### PR TITLE
修改easyorm中校验器和触发器的执行顺序，先执行校验器后执行触发器；

### DIFF
--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/simple/SimpleInsert.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/simple/SimpleInsert.java
@@ -47,11 +47,13 @@ class SimpleInsert<T> extends ValidatorAndTriggerSupport<Insert<T>> implements I
 
     @Override
     public int exec() throws SQLException {
+        tryValidate(insertParam.getData(), Validator.Operation.INSERT);
         boolean supportBefore = !triggerSkip && table.getMeta().triggerIsSupport(Trigger.insert_before);
         boolean supportDone = !triggerSkip && table.getMeta().triggerIsSupport(Trigger.insert_done);
         Map<String, Object> context =null;
         if (supportBefore || supportDone) {
             context = table.getDatabase().getTriggerContextRoot();
+            table.createQuery().where("","").and("","").total();
             context.put("table", table);
             context.put("database", table.getDatabase());
             context.put("param", insertParam);
@@ -61,7 +63,6 @@ class SimpleInsert<T> extends ValidatorAndTriggerSupport<Insert<T>> implements I
         }
         SqlRender<InsertParam> render = table.getMeta().getDatabaseMetaData().getRenderer(SqlRender.TYPE.INSERT);
         SQL sql = render.render(table.getMeta(), insertParam);
-        tryValidate(insertParam.getData(), Validator.Operation.INSERT);
         int total = sqlExecutor.insert(sql);
         if (supportDone) {
             context.put("total", total);

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/simple/SimpleUpdate.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/simple/SimpleUpdate.java
@@ -138,6 +138,7 @@ class SimpleUpdate<T> extends ValidatorAndTriggerSupport<Update<T>> implements U
 
     @Override
     public int exec() throws SQLException {
+        tryValidate(updateParam.getData(), Validator.Operation.UPDATE);
         boolean supportBefore = !triggerSkip && table.getMeta().triggerIsSupport(Trigger.update_before);
         boolean supportDone = !triggerSkip && table.getMeta().triggerIsSupport(Trigger.update_done);
         Map<String, Object> context = null;
@@ -152,7 +153,6 @@ class SimpleUpdate<T> extends ValidatorAndTriggerSupport<Update<T>> implements U
         }
         SqlRender<UpdateParam> render = table.getMeta().getDatabaseMetaData().getRenderer(SqlRender.TYPE.UPDATE);
         SQL sql = render.render(table.getMeta(), updateParam);
-        tryValidate(updateParam.getData(), Validator.Operation.UPDATE);
         int total = sqlExecutor.update(sql);
         if (supportDone) {
             context.put("total", total);


### PR DESCRIPTION
提PR前提：大多数情况，easyorm动态表单都是会校验器+触发器联合使用，触发器的功能是可以包含校验器的功能的，触发器先触发，就感觉校验器的功能有点多余了。

修改内容：
修改easyorm中校验器和触发器的执行顺序，先执行校验器后执行触发器；