### PR TITLE
MSSQLDialect对tinyint的处理转为smallint类型

### DIFF
--- a/hsweb-easy-orm-core/pom.xml
+++ b/hsweb-easy-orm-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hsweb-easy-orm</artifactId>
         <groupId>org.hswebframework</groupId>
-        <version>3.0.6</version>
+        <version>3.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hsweb-easy-orm-elasticsearch/pom.xml
+++ b/hsweb-easy-orm-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hsweb-easy-orm</artifactId>
         <groupId>org.hswebframework</groupId>
-        <version>3.0.6</version>
+        <version>3.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hsweb-easy-orm-rdb/pom.xml
+++ b/hsweb-easy-orm-rdb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hsweb-easy-orm</artifactId>
         <groupId>org.hswebframework</groupId>
-        <version>3.0.6</version>
+        <version>3.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/meta/RDBTableMetaData.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/meta/RDBTableMetaData.java
@@ -71,7 +71,7 @@ public class RDBTableMetaData extends AbstractTableMetaData<RDBColumnMetaData> i
     @Override
     public RDBColumnMetaData getColumn(String name) {
         RDBColumnMetaData metaData = columnMetaDataMap.get(name);
-        if (metaData == null) metaData = columnMetaDataMap.get(name);
+        if (metaData == null) metaData = aliasColumnMetaDataMap.get(name);
         return metaData;
     }
 

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/render/dialect/MSSQLDialect.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/render/dialect/MSSQLDialect.java
@@ -34,7 +34,7 @@ public class MSSQLDialect extends DefaultDialect {
         setDataTypeMapper(JDBCType.INTEGER, (meta) -> "int");
         setDataTypeMapper(JDBCType.NUMERIC, (meta) -> StringUtils.concat("numeric(", meta.getPrecision(), ",", meta.getScale(), ")"));
         setDataTypeMapper(JDBCType.DECIMAL, (meta) -> StringUtils.concat("numeric(", meta.getPrecision(), ",", meta.getScale(), ")"));
-        setDataTypeMapper(JDBCType.TINYINT, (meta) -> "tinyint");
+        setDataTypeMapper(JDBCType.TINYINT, (meta) -> "smallint");
         setDataTypeMapper(JDBCType.BIGINT, (meta) -> "bigint");
         setDataTypeMapper(JDBCType.OTHER, (meta) -> "other");
         setDataTypeMapper(JDBCType.REAL, (meta) -> "real");
@@ -62,7 +62,7 @@ public class MSSQLDialect extends DefaultDialect {
         setJdbcTypeMapping("sysname", JDBCType.VARCHAR);
         setJdbcTypeMapping("text", JDBCType.LONGVARCHAR);
         setJdbcTypeMapping("timestamp", JDBCType.BINARY);
-        setJdbcTypeMapping("tinyint", JDBCType.TINYINT);
+        setJdbcTypeMapping("tinyint", JDBCType.SMALLINT);
         setJdbcTypeMapping("uniqueidentifier", JDBCType.CHAR);
         setJdbcTypeMapping("varbinary", JDBCType.VARBINARY);
         setJdbcTypeMapping("varchar", JDBCType.VARCHAR);

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.hswebframework</groupId>
     <artifactId>hsweb-easy-orm</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.6</version>
+    <version>3.0.7-SNAPSHOT</version>
     <modules>
         <module>hsweb-easy-orm-core</module>
         <module>hsweb-easy-orm-rdb</module>


### PR DESCRIPTION
mssql中创建table时tinyint属性默认为无符号，此PR提交对tinyint的sqlType从tinyint改为smallint，已单元测试通过