### PR TITLE
refactor: 优化批量新增保存时重复数据的处理逻辑:合并相同的数据.

### DIFF
--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/mapping/defaults/DefaultReactiveRepository.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/mapping/defaults/DefaultReactiveRepository.java
@@ -95,9 +95,8 @@ public class DefaultReactiveRepository<E, K> extends DefaultRepository<E> implem
     public Mono<Integer> insert(Publisher<E> data) {
         return Flux
                 .from(data)
-                .flatMap(e -> doInsert(e).reactive().as(this::setupLogger))
-                .reduce(Math::addExact)
-                .defaultIfEmpty(0);
+                .buffer(100)
+                .as(this::insertBatch);
     }
 
     @Override

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/BasicReactiveTests.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/BasicReactiveTests.java
@@ -194,6 +194,48 @@ public abstract class BasicReactiveTests {
     }
 
     @Test
+    public void testInsertMerge(){
+
+        BasicTestEntity first= BasicTestEntity
+                .builder()
+                .id("test_merge")
+                .balance(1000L)
+                .name("first")
+                .createTime(new Date())
+                .tags(Arrays.asList("a", "b", "c", "d"))
+                .state((byte) 1)
+                .stateEnum(StateEnum.enabled)
+                .build();
+
+        BasicTestEntity second= BasicTestEntity
+                .builder()
+                .id("test_merge")
+                .balance(1000L)
+                .name("second")
+                .createTime(new Date())
+                .tags(Arrays.asList("a", "b", "c", "d"))
+                .state((byte) 1)
+                .stateEnum(StateEnum.enabled)
+                .build();
+
+        repository
+                .insert(Flux.just(first,second))
+                .as(StepVerifier::create)
+                .expectNext(1)
+                .verifyComplete();
+
+        repository
+                .createQuery()
+                .where(BasicTestEntity::getId,first.getId())
+                .select("id","name")
+                .fetch()
+                .map(BasicTestEntity::getName)
+                .as(StepVerifier::create)
+                .expectNext(second.getName())
+                .verifyComplete();
+    }
+
+    @Test
     public void testInsertDuplicate() {
         //10次insert
         Flux.just(1, 2, 2, 3, 3, 1)

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlIndexMetadataParserTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlIndexMetadataParserTest.java
@@ -33,7 +33,7 @@ public class PostgresqlIndexMetadataParserTest {
 
 
 
-            sqlExecutor.execute(SqlRequests.of("create index test_index on test_index_parser (age)"));
+            sqlExecutor.execute(SqlRequests.of("create index test_index_0 on test_index_parser (age)"));
 
             sqlExecutor.execute(SqlRequests.of("create unique index test_index_2 on test_index_parser (name)"));
 


### PR DESCRIPTION
当批量操作时，如果一个批次中存在相同的数据(id相同),新的数据将会于旧的数据进行合并(属性会发生变更).