### PR TITLE
新增当toType是TimeStamp类型时的转换

### DIFF
--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/DateTimeCodec.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/DateTimeCodec.java
@@ -115,6 +115,9 @@ public class DateTimeCodec implements ValueCodec {
         if (toType == String.class) {
             return DateTimeUtils.format(((Date) data), format);
         }
+        if (toType == Timestamp.class){
+            return new Timestamp(((Date) data).getTime());
+        }
 
         return data;
     }


### PR DESCRIPTION
在使用下面这个sql查询时会报错 "java.util.Date cannot be cast to java.sql.Timestamp" 

------------------------------------------业务原始查询如下：--------------------------------------

`return queryHelper.select(DeviceWithLatestReport.class)
                            .as(DeviceLatestReportMessageEntity::getRecvTime, DeviceWithLatestReport::setRecvTime)
                            .from(DeviceInstanceEntity.class)
                            .leftJoin(DeviceLatestReportMessageEntity.class, joinConditionalSpec -> joinConditionalSpec.alias("device")
                                .is(DeviceInstanceEntity::getId, DeviceLatestReportMessageEntity::getDeviceId))
                            .where(dsl -> {
                                dsl.accept(queryParamEntity);
                            })
                            .fetchPaged();`

其中 DeviceLatestReportMessageEntity#recvTime 定义如下：
    @Column()
    @Schema(description = "上告时间")
    private Timestamp recvTime;

 同样 DeviceWithLatestReport实体中也定义了同样的字段名称和类型
 但是在使用 QueryHelper进行查询的时候，会抛 "java.util.Date cannot be cast to java.sql.Timestamp" 异常


 ------------------------------------ 问题定位 ------------------------------------------------------------------
 查看了源码实现，对于 Timestamp类型的字段，orm中是使用 org/hswebframework/ezorm/rdb/codec/DateTimeCodec.java 进行decode的，这一步会将数据库中 recvTime查询出来的 java.time.ZonedDateTime 类型数据转成 java.util.Date 类型，但是 .as(DeviceLatestReportMessageEntity::getRecvTime, DeviceWithLatestReport::setRecvTime) 方法会将 org.hswebframework.web.crud.query.DefaultQueryHelper.ColumnMapping.Default#getter 和  org.hswebframework.web.crud.query.DefaultQueryHelper.ColumnMapping.Default#setter 中泛型V都识别成 java.sql.Timestamp 类型，然后在 org.hswebframework.web.crud.query.DefaultQueryHelper.ColumnMapping.Default#applyValue 方法中 ， 会直接使用setter进行设置实体的值，但是在设置之前会把 (V)metadata.decode(sqlValue) 后的值 也就是 java.util.Date 强转为 java.sql.Timestamp ，因此会报错
`@Override
            void applyValue(R result, String[] column, Object sqlValue) {
                if (setter != null) {
                    setter.accept(result, (V) metadata.decode(sqlValue));
                    return;
                }
                GlobalConfig.getPropertyOperator().setProperty(result, column[0], metadata.decode(sqlValue));
            }
`

最后： 因此在DateTimeCodec的 decode 方法中增加了 toType  == Timestamp 类型的处理，这样处理之后，即使强转也能正常运行


    

