### PR TITLE
refactor: 优化对枚举类型的支持

### DIFF
--- a/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/ObjectPropertyOperator.java
+++ b/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/ObjectPropertyOperator.java
@@ -2,6 +2,7 @@ package org.hswebframework.ezorm.core;
 
 import lombok.SneakyThrows;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public interface ObjectPropertyOperator {
@@ -10,13 +11,33 @@ public interface ObjectPropertyOperator {
 
     void setProperty(Object object, String name, Object value);
 
+    /**
+     * 对比两个对象
+     * @param left left
+     * @param right right
+     * @return
+     */
+    @SuppressWarnings("all")
+    default int compare(Object left, Object right) {
+        if (Objects.equals(left, right)) {
+            return 0;
+        }
+        if (left.getClass() == right.getClass() && left instanceof Comparable) {
+            return ((Comparable) left).compareTo(right);
+        }
+        if (left instanceof Number && right instanceof Number) {
+            return Double.compare(((Number) left).doubleValue(), ((Number) right).doubleValue());
+        }
+        return -1;
+    }
+
     @SneakyThrows
     default Optional<Class<?>> getPropertyType(Object object, String name) {
         try {
             return Optional.of(object
-                                       .getClass()
-                                       .getDeclaredField(name)
-                                       .getType());
+                                   .getClass()
+                                   .getDeclaredField(name)
+                                   .getType());
         } catch (Throwable e) {
             return Optional.empty();
         }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/mapping/annotation/EnumCodec.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/mapping/annotation/EnumCodec.java
@@ -12,11 +12,24 @@ import java.lang.annotation.*;
 @Codec
 public @interface EnumCodec {
 
+    String
+        NAME = "name",
+        ORDINAL = "ordinal";
+
     /**
      * @return 是否使用将枚举的序号进行位掩码以实现多选
      * @see java.sql.JDBCType#NUMERIC
      * @see Long
      */
     boolean toMask() default false;
+
+    /**
+     * 使用指定的枚举属性作为数据库的值,默认{@link Enum#name()}
+     *
+     * @return value
+     * @see Enum#name()
+     * @see Enum#ordinal()
+     */
+    String property() default NAME;
 
 }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/mapping/parser/DefaultValueCodecResolver.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/mapping/parser/DefaultValueCodecResolver.java
@@ -35,7 +35,7 @@ public class DefaultValueCodecResolver implements ValueCodecResolver {
 
         COMMONS.register(JsonCodec.class, (field, jsonCodec) -> JsonValueCodec.ofField(field.getField()));
 
-        COMMONS.register(EnumCodec.class, (field, jsonCodec) -> new EnumValueCodec(field.getPropertyType(), jsonCodec.toMask()));
+        COMMONS.register(EnumCodec.class, (field, jsonCodec) -> new EnumValueCodec(field.getPropertyType(), jsonCodec.property(), jsonCodec.toMask()));
         COMMONS.register(Enumerated.class, (field, jsonCodec) -> new EnumValueCodec(field.getPropertyType(), jsonCodec.value()== EnumType.ORDINAL));
 
         COMMONS.register(Date.class::isAssignableFrom, field -> new org.hswebframework.ezorm.rdb.codec.DateTimeCodec("yyyy-MM-dd HH:mm:dd", field.getPropertyType()));

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleDialect.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleDialect.java
@@ -50,7 +50,7 @@ public class OracleDialect extends DefaultDialect {
         registerDataType("longvarchar", DataType.builder(JdbcDataType.of(JDBCType.LONGVARCHAR, String.class), c -> "clob"));
 
         registerDataType("varchar2", DataType.builder(DataType.jdbc(JDBCType.VARCHAR, String.class),
-                                                      column -> "varchar2(" + column.getLength() + "  char)"));
+                                                      column -> "varchar2(" + column.getLength() + " char)"));
 
         registerDataType("nvarchar2", DataType.builder(DataType.jdbc(JDBCType.VARCHAR, String.class),
                                                        column -> "nvarchar2(" + column.getLength() + ")"));

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/EnumValueCodecTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/EnumValueCodecTest.java
@@ -46,15 +46,31 @@ public class EnumValueCodecTest {
 
         EnumValueCodec codec = new EnumValueCodec(TestEnum[].class, true);
 
-        Assert.assertEquals(3L, codec.encode(new TestEnum[]{TestEnum.A,TestEnum.B}));
+        Assert.assertEquals(3L, codec.encode(new TestEnum[]{TestEnum.A, TestEnum.B}));
 
-        Assert.assertArrayEquals(new TestEnum[]{TestEnum.A,TestEnum.B}, (Object[]) codec.decode(3));
+        Assert.assertArrayEquals(new TestEnum[]{TestEnum.A, TestEnum.B}, (Object[]) codec.decode(3));
 
     }
 
+    @Test
+    public void testCustomProperty() {
+        EnumValueCodec codec = new EnumValueCodec(TestEnum.class, "property",false);
+
+        for (TestEnum value : TestEnum.values()) {
+            assertEquals(value, codec.decode(Long.valueOf(value.property).intValue()));
+        }
+
+    }
 
     public enum TestEnum {
         A, B, C;
+
+        final long property  = ordinal() * 10;
+
+        public long getProperty() {
+            return property;
+        }
     }
+
 
 }

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleTableMetaParserTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleTableMetaParserTest.java
@@ -136,9 +136,9 @@ public class OracleTableMetaParserTest {
 
                 Assert.assertNotNull(column);
 
-                Assert.assertEquals(column.getDataType(), "varchar2(32 char)");
-                Assert.assertEquals(column.getType().getSqlType(), JDBCType.VARCHAR);
-                Assert.assertEquals(column.getJavaType(), String.class);
+                Assert.assertEquals("varchar2(32 char)", column.getDataType());
+                Assert.assertEquals(JDBCType.VARCHAR, column.getType().getSqlType());
+                Assert.assertEquals(String.class, column.getJavaType());
                 Assert.assertTrue(column.isNotNull());
                 // 这里只解析表结构，而不会解析键信息.
                 // Assert.assertTrue(column.isPrimaryKey());

--- a/hsweb-easy-orm-rdb/src/test/resources/logback.xml
+++ b/hsweb-easy-orm-rdb/src/test/resources/logback.xml
@@ -18,7 +18,7 @@
         </encoder>
     </appender>
 
-    <root level="debug">
+    <root level="info">
         　
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
```java
....
@EnumCodec(property="value") // 以指定的枚举属性来作为数据库值
private MyEnum myEnum;
````

```java
@Getter
@AllArgsConstructor
enum MyEnum{
    a(1),b(2),c(3);
    
    final int value;
}
```