### PR TITLE
refactor(基础模块): 优化对clob的支持

### DIFF
--- a/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/ValueCodec.java
+++ b/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/ValueCodec.java
@@ -12,6 +12,10 @@ public interface ValueCodec<E, D> extends Encoder<E>, Decoder<D> {
 
     D decode(Object data);
 
+    default E encodeNull(ColumnMetadata column){
+        return encodeNull();
+    }
+
     default E encode(Object value, ColumnMetadata column){
         return encode(value);
     }

--- a/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/meta/AbstractColumnMetadata.java
+++ b/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/meta/AbstractColumnMetadata.java
@@ -58,7 +58,7 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
     public Object encode(Object data) {
         if (data == null) {
             if (valueCodec != null) {
-                return valueCodec.encodeNull();
+                return valueCodec.encodeNull(this);
             }
             return null;
         }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/ClobValueCodec.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/ClobValueCodec.java
@@ -5,6 +5,8 @@ import io.netty.buffer.ByteBuf;
 import lombok.SneakyThrows;
 import org.hswebframework.ezorm.core.ValueCodec;
 import org.hswebframework.ezorm.core.meta.ColumnMetadata;
+import org.hswebframework.ezorm.rdb.executor.NullValue;
+import org.hswebframework.ezorm.rdb.metadata.DataType;
 import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
 import org.hswebframework.ezorm.rdb.utils.FeatureUtils;
 import reactor.core.publisher.Flux;
@@ -21,14 +23,29 @@ public class ClobValueCodec implements ValueCodec {
 
     public static final ClobValueCodec INSTANCE = new ClobValueCodec();
 
+    static boolean isClobType(DataType type) {
+        return type.getSqlType() == JDBCType.LONGVARCHAR ||
+            type.getSqlType() == JDBCType.LONGNVARCHAR ||
+            type.getSqlType() == JDBCType.CLOB;
+    }
+
+    @Override
+    public Object encodeNull(ColumnMetadata column) {
+        if (column instanceof RDBColumnMetadata col) {
+            if (ClobValueCodec.isClobType(col.getType())) {
+                return NullValue.of(LongCharSequence.class, col.getType());
+            }
+            return NullValue.of(col.getType());
+        }
+        return null;
+    }
+
     @Override
     public Object encode(Object value, ColumnMetadata column) {
         Object val = this.encode(value);
         if (val instanceof CharSequence cs && column instanceof RDBColumnMetadata col) {
-            if (col.getType().getSqlType() == JDBCType.LONGVARCHAR ||
-                col.getType().getSqlType() == JDBCType.LONGNVARCHAR ||
-                col.getType().getSqlType() == JDBCType.CLOB) {
-                return new ClobValue(cs);
+            if (ClobValueCodec.isClobType(col.getType())) {
+                return new LongCharSequence(cs);
             }
         }
         return val;

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/ClobValueCodec.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/ClobValueCodec.java
@@ -8,6 +8,7 @@ import org.hswebframework.ezorm.core.meta.ColumnMetadata;
 import org.hswebframework.ezorm.rdb.executor.NullValue;
 import org.hswebframework.ezorm.rdb.metadata.DataType;
 import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.supports.oracle.OracleDialect;
 import org.hswebframework.ezorm.rdb.utils.FeatureUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -23,7 +24,7 @@ public class ClobValueCodec implements ValueCodec {
 
     public static final ClobValueCodec INSTANCE = new ClobValueCodec();
 
-    static boolean isClobType(DataType type) {
+    public static boolean isClobType(DataType type) {
         return type.getSqlType() == JDBCType.LONGVARCHAR ||
             type.getSqlType() == JDBCType.LONGNVARCHAR ||
             type.getSqlType() == JDBCType.CLOB;

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/JsonValueCodec.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/JsonValueCodec.java
@@ -11,6 +11,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.hswebframework.ezorm.core.ValueCodec;
 import org.hswebframework.ezorm.core.meta.ColumnMetadata;
+import org.hswebframework.ezorm.rdb.executor.NullValue;
 import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
 import org.hswebframework.ezorm.rdb.utils.FeatureUtils;
 import org.reactivestreams.Publisher;
@@ -24,7 +25,6 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.sql.Blob;
 import java.sql.Clob;
-import java.sql.JDBCType;
 import java.util.Collection;
 import java.util.Map;
 import java.util.TimeZone;
@@ -105,14 +105,24 @@ public class JsonValueCodec implements ValueCodec<Object, Object> {
     }
 
     @Override
+    public Object encodeNull(ColumnMetadata column) {
+        if (column instanceof RDBColumnMetadata col) {
+            // clob 类型
+            if (ClobValueCodec.isClobType(col.getType())) {
+                return NullValue.of(LongCharSequence.class, col.getType());
+            }
+            return NullValue.of(col.getType());
+        }
+        return ValueCodec.super.encodeNull(column);
+    }
+
+    @Override
     public Object encode(Object value, ColumnMetadata column) {
         Object data = encode(value);
         if (data instanceof CharSequence cs && column instanceof RDBColumnMetadata col) {
             // clob 类型
-            if (col.getType().getSqlType() == JDBCType.LONGVARCHAR ||
-                col.getType().getSqlType() == JDBCType.LONGNVARCHAR ||
-                col.getType().getSqlType() == JDBCType.CLOB) {
-                return new ClobValue(cs);
+            if (ClobValueCodec.isClobType(col.getType())) {
+                return new LongCharSequence(cs);
             }
         }
         return data;

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/JsonValueCodec.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/JsonValueCodec.java
@@ -19,6 +19,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.InputStream;
+import java.io.Reader;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -159,27 +160,29 @@ public class JsonValueCodec implements ValueCodec<Object, Object> {
         try {
             Object target = data;
 
-            if (data instanceof Clob) {
-                target = mapper.readValue(((Clob) data).getCharacterStream(), jacksonType);
-            } else if (data instanceof Blob) {
-                target = mapper.readValue(((Blob) data).getBinaryStream(), jacksonType);
+            if (data instanceof Clob _clob) {
+                target = mapper.readValue(_clob.getCharacterStream(), jacksonType);
+            } else if (data instanceof Blob _blob) {
+                target = mapper.readValue(_blob.getBinaryStream(), jacksonType);
             } else if (data instanceof InputStream) {
                 target = mapper.readValue((InputStream) data, jacksonType);
-            } else if (data instanceof byte[]) {
-                target = mapper.readValue((byte[]) data, jacksonType);
-            } else if (data instanceof String) {
-                target = doRead(((String) data));
+            } else if (data instanceof byte[] bytes) {
+                target = mapper.readValue(bytes, jacksonType);
+            } else if (data instanceof CharSequence) {
+                target = doRead(String.valueOf(data));
+            } else if (data instanceof Reader reader) {
+                target = mapper.readValue(reader, jacksonType);
             } else if (data instanceof ByteBuffer) {
                 return doRead(new ByteBufferBackedInputStream(((ByteBuffer) data)));
             } else if (FeatureUtils.r2dbcIsAlive()) {
                 Mono<?> mono = null;
-                if (data instanceof io.r2dbc.spi.Clob) {
-                    mono = Flux.from(((io.r2dbc.spi.Clob) data).stream())
+                if (data instanceof io.r2dbc.spi.Clob _clob) {
+                    mono = Flux.from(_clob.stream())
                                .collect(Collectors.joining())
                                .map(this::doRead);
 
-                } else if (data instanceof io.r2dbc.spi.Blob) {
-                    mono = Mono.from(((io.r2dbc.spi.Blob) data).stream())
+                } else if (data instanceof io.r2dbc.spi.Blob _blob) {
+                    mono = Mono.from(_blob.stream())
                                .map(ByteBufferBackedInputStream::new)
                                .map(this::doRead);
                 }
@@ -203,6 +206,9 @@ public class JsonValueCodec implements ValueCodec<Object, Object> {
             }
             if (targetType == Flux.class) {
                 return target == null ? Flux.empty() : Flux.just(target);
+            }
+            if (target == null) {
+                return null;
             }
             log.warn("unsupported json format:{}", data);
             return target;

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/LongCharSequence.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/codec/LongCharSequence.java
@@ -1,18 +1,16 @@
 package org.hswebframework.ezorm.rdb.codec;
 
-import org.reactivestreams.Publisher;
 import reactor.util.annotation.NonNull;
 
-import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.stream.IntStream;
 
-public class ClobValue implements CharSequence {
+public class LongCharSequence implements CharSequence {
 
     private final CharSequence charSequence;
 
-    public ClobValue(CharSequence charSequence) {
+    public LongCharSequence(CharSequence charSequence) {
         this.charSequence = charSequence;
     }
 

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/NullValue.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/NullValue.java
@@ -8,18 +8,21 @@ import org.hswebframework.ezorm.rdb.metadata.DataType;
 @Getter
 @AllArgsConstructor(staticName = "of")
 public class NullValue {
-    @Deprecated
-    private Class type;
 
-    @NonNull
+    private Class<?> type;
+
     private DataType dataType;
 
-    public static NullValue of(DataType dataType){
-        return of(dataType.getJavaType(),dataType);
+    public static NullValue of(DataType dataType) {
+        return of(dataType.getJavaType(), dataType);
+    }
+
+    public Class<?> getType() {
+        return type == null ? dataType.getJavaType() : type;
     }
 
     @Override
     public String toString() {
-        return "null" + (dataType==null?"": (type != null ? "(" + dataType.getId() + ")" : ""));
+        return "null" + (type != null ? "("+type.getSimpleName()+")" : (dataType != null ? "(" + dataType.getId() + ")" : ""));
     }
 }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutorHelper.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutorHelper.java
@@ -38,12 +38,7 @@ public class JdbcSqlExecutorHelper {
             if (object == null) {
                 statement.setNull(index++, Types.NULL);
             } else if (object instanceof NullValue nullValue) {
-                Class<?> javaType = nullValue.getType();
-                if (LongCharSequence.class == javaType) {
-                    statement.setCharacterStream(index++, new StringReader(""));
-                } else {
-                    statement.setNull(index++, nullValue.getDataType().getSqlType().getVendorTypeNumber());
-                }
+                statement.setNull(index++, nullValue.getDataType().getSqlType().getVendorTypeNumber());
             } else if (object instanceof Date) {
                 statement.setTimestamp(index++, new java.sql.Timestamp(((Date) object).getTime()));
             } else if (object instanceof byte[] b) {

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutorHelper.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutorHelper.java
@@ -1,12 +1,11 @@
 package org.hswebframework.ezorm.rdb.executor.jdbc;
 
 import lombok.SneakyThrows;
-import org.hswebframework.ezorm.rdb.codec.ClobValue;
+import org.hswebframework.ezorm.rdb.codec.LongCharSequence;
 import org.hswebframework.ezorm.rdb.executor.NullValue;
 
-import javax.sql.rowset.serial.SerialClob;
 import java.io.ByteArrayInputStream;
-import java.io.CharArrayReader;
+import java.io.StringReader;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Date;
@@ -38,18 +37,22 @@ public class JdbcSqlExecutorHelper {
         for (Object object : parameter) {
             if (object == null) {
                 statement.setNull(index++, Types.NULL);
-            } else if (object instanceof NullValue) {
-                statement.setNull(index++, ((NullValue) object).getDataType().getSqlType().getVendorTypeNumber());
+            } else if (object instanceof NullValue nullValue) {
+                Class<?> javaType = nullValue.getType();
+                if (LongCharSequence.class == javaType) {
+                    statement.setCharacterStream(index++, new StringReader(""));
+                } else {
+                    statement.setNull(index++, nullValue.getDataType().getSqlType().getVendorTypeNumber());
+                }
             } else if (object instanceof Date) {
                 statement.setTimestamp(index++, new java.sql.Timestamp(((Date) object).getTime()));
             } else if (object instanceof byte[] b) {
                 statement.setBlob(index++, new ByteArrayInputStream(b));
-            } else if (object instanceof ClobValue cb) {
+            } else if (object instanceof LongCharSequence cb) {
                 statement.setCharacterStream(index++, cb.reader());
             } else {
                 statement.setObject(index++, object);
             }
-
         }
     }
 

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/reactive/r2dbc/R2dbcReactiveSqlExecutor.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/reactive/r2dbc/R2dbcReactiveSqlExecutor.java
@@ -252,7 +252,14 @@ public abstract class R2dbcReactiveSqlExecutor implements ReactiveSqlExecutor {
             if (parameter == null) {
                 bindNull(statement, index, String.class);
             } else if (parameter instanceof NullValue nullValue) {
-                bindNull(statement, index, nullValue.getType());
+                Class<?> javaType = nullValue.getType();
+                if (javaType == LongCharSequence.class) {
+                    // 空字符,批量保存时,有的数据库不同行不能有的设置null有的不设置.
+                    bindNull(statement, index, Clob.class);
+                }else {
+                    bindNull(statement, index, javaType);
+                }
+
             } else {
                 // convert clob
                 if (parameter instanceof LongCharSequence cb) {

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/reactive/r2dbc/R2dbcReactiveSqlExecutor.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/reactive/r2dbc/R2dbcReactiveSqlExecutor.java
@@ -252,11 +252,7 @@ public abstract class R2dbcReactiveSqlExecutor implements ReactiveSqlExecutor {
             if (parameter == null) {
                 bindNull(statement, index, String.class);
             } else if (parameter instanceof NullValue nullValue) {
-                Class<?> javaType = nullValue.getType();
-                if (javaType == LongCharSequence.class) {
-                    javaType = Clob.class;
-                }
-                bindNull(statement, index, javaType);
+                bindNull(statement, index, nullValue.getType());
             } else {
                 // convert clob
                 if (parameter instanceof LongCharSequence cb) {

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/reactive/r2dbc/R2dbcReactiveSqlExecutor.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/reactive/r2dbc/R2dbcReactiveSqlExecutor.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.hswebframework.ezorm.core.CastUtil;
-import org.hswebframework.ezorm.rdb.codec.ClobValue;
+import org.hswebframework.ezorm.rdb.codec.LongCharSequence;
 import org.hswebframework.ezorm.rdb.executor.BatchSqlRequest;
 import org.hswebframework.ezorm.rdb.executor.DefaultColumnWrapperContext;
 import org.hswebframework.ezorm.rdb.executor.NullValue;
@@ -251,11 +251,15 @@ public abstract class R2dbcReactiveSqlExecutor implements ReactiveSqlExecutor {
         for (Object parameter : request.getParameters()) {
             if (parameter == null) {
                 bindNull(statement, index, String.class);
-            } else if (parameter instanceof NullValue) {
-                bindNull(statement, index, ((NullValue) parameter).getDataType().getJavaType());
+            } else if (parameter instanceof NullValue nullValue) {
+                Class<?> javaType = nullValue.getType();
+                if (javaType == LongCharSequence.class) {
+                    javaType = Clob.class;
+                }
+                bindNull(statement, index, javaType);
             } else {
                 // convert clob
-                if (parameter instanceof ClobValue cb) {
+                if (parameter instanceof LongCharSequence cb) {
                     parameter = Clob.from(Mono.just(cb.source()));
                 }
                 bind(statement, index, parameter);

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/metadata/RDBColumnMetadata.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/metadata/RDBColumnMetadata.java
@@ -221,7 +221,7 @@ public class RDBColumnMetadata extends AbstractColumnMetadata implements ColumnM
     public Object encode(Object data) {
         if (data == null || data instanceof NullValue) {
             if (valueCodec != null) {
-                Object newVal = valueCodec.encodeNull();
+                Object newVal = valueCodec.encodeNull(this);
                 if (newVal != null) {
                     return newVal;
                 }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleBatchUpsertOperator.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleBatchUpsertOperator.java
@@ -1,8 +1,11 @@
 package org.hswebframework.ezorm.rdb.supports.oracle;
 
+import io.r2dbc.mssql.codec.ClobCodec;
 import lombok.AllArgsConstructor;
 import org.hswebframework.ezorm.core.RuntimeDefaultValue;
 import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.rdb.codec.ClobValueCodec;
+import org.hswebframework.ezorm.rdb.codec.LongCharSequence;
 import org.hswebframework.ezorm.rdb.executor.NullValue;
 import org.hswebframework.ezorm.rdb.executor.SqlRequest;
 import org.hswebframework.ezorm.rdb.executor.SyncSqlExecutor;
@@ -188,9 +191,15 @@ public class OracleBatchUpsertOperator implements SaveOrUpdateOperator {
                             value = NullValue.of(column.getType());
                         }
                     }
-
+                    value = column.encode(value);
+                    // 适配 clob字段 不支持设置null
+                    if (valueSize > 1 && (value == null || value instanceof NullValue)) {
+                        if (ClobValueCodec.isClobType(column.getType())) {
+                            value = new LongCharSequence("");
+                        }
+                    }
                     fragments.addSql("? as ", column.getQuoteName())
-                             .addParameter(column.encode(value));
+                             .addParameter(value);
                     valueIndex++;
                 }
 

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleInsertSqlBuilder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleInsertSqlBuilder.java
@@ -3,6 +3,8 @@ package org.hswebframework.ezorm.rdb.supports.oracle;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hswebframework.ezorm.core.RuntimeDefaultValue;
+import org.hswebframework.ezorm.rdb.codec.ClobValueCodec;
+import org.hswebframework.ezorm.rdb.codec.LongCharSequence;
 import org.hswebframework.ezorm.rdb.executor.NullValue;
 import org.hswebframework.ezorm.rdb.executor.SqlRequest;
 import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
@@ -126,7 +128,14 @@ public class OracleInsertSqlBuilder implements InsertSqlBuilder {
                 if (value == null) {
                     value = NullValue.of(column.getType());
                 }
-                valuesSql.add(SqlFragments.QUESTION_MARK).addParameter(column.encode(value));
+                value = column.encode(value);
+                // 适配 clob字段 不支持设置null
+                if (valueSize > 1 && (value == null || value instanceof NullValue)) {
+                    if (ClobValueCodec.isClobType(column.getType())) {
+                        value = new LongCharSequence("");
+                    }
+                }
+                valuesSql.add(SqlFragments.QUESTION_MARK).addParameter(value);
             }
             intoSql.add(SqlFragments.RIGHT_BRACKET);
             valuesSql.add(SqlFragments.RIGHT_BRACKET);

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/BasicCommonTests.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/BasicCommonTests.java
@@ -14,6 +14,7 @@ import org.hswebframework.ezorm.rdb.mapping.EntityColumnMapping;
 import org.hswebframework.ezorm.rdb.mapping.MappingFeatureType;
 import org.hswebframework.ezorm.rdb.mapping.SyncRepository;
 import org.hswebframework.ezorm.rdb.mapping.defaults.DefaultSyncRepository;
+import org.hswebframework.ezorm.rdb.mapping.defaults.SaveResult;
 import org.hswebframework.ezorm.rdb.mapping.defaults.record.Record;
 import org.hswebframework.ezorm.rdb.mapping.defaults.record.RecordResultWrapper;
 import org.hswebframework.ezorm.rdb.mapping.jpa.JpaEntityTableMetadataParser;
@@ -107,8 +108,8 @@ public abstract class BasicCommonTests {
               });
 
         RDBTableMetadata table = parser
-                .parseTableMetadata(BasicTestEntity.class)
-                .orElseThrow(NullPointerException::new);
+            .parseTableMetadata(BasicTestEntity.class)
+            .orElseThrow(NullPointerException::new);
 
         //  table.addFeature((EventListener) (type, context) -> log.debug("event:{},context:{}", type, context));
 
@@ -117,10 +118,10 @@ public abstract class BasicCommonTests {
                 .commit()
                 .sync();
         NestedEntityResultWrapper wrapper =
-                table
-                        .<EntityColumnMapping>getFeature(MappingFeatureType.columnPropertyMapping.createFeatureId(BasicTestEntity.class))
-                        .map(mapping -> new NestedEntityResultWrapper(mapping))
-                        .orElseThrow(NullPointerException::new);
+            table
+                .<EntityColumnMapping>getFeature(MappingFeatureType.columnPropertyMapping.createFeatureId(BasicTestEntity.class))
+                .map(mapping -> new NestedEntityResultWrapper(mapping))
+                .orElseThrow(NullPointerException::new);
 
         repository = new DefaultSyncRepository<>(operator, table, BasicTestEntity.class, wrapper);
         addressRepository = operator.dml().createRepository("test_address");
@@ -145,17 +146,17 @@ public abstract class BasicCommonTests {
     @Test
     public void testRepositoryInsertBach() {
         List<BasicTestEntity> entities = Flux
-                .range(0, 100)
-                .map(integer -> BasicTestEntity.builder()
-                                               // .id("test_id_" + integer)
-                                               .balance(1000L)
-                                               .name("test:" + integer)
-                                               .createTime(new Date())
-                                               .tags(Arrays.asList("a", "b", "c", "d"))
-                                               .state((byte) 1)
-                                               // .stateEnum(StateEnum.enabled)
-                                               .build())
-                .collectList().block();
+            .range(0, 100)
+            .map(integer -> BasicTestEntity.builder()
+                                           // .id("test_id_" + integer)
+                                           .balance(1000L)
+                                           .name("test:" + integer)
+                                           .createTime(new Date())
+                                           .tags(Arrays.asList("a", "b", "c", "d"))
+                                           .state((byte) 1)
+                                           // .stateEnum(StateEnum.enabled)
+                                           .build())
+            .collectList().block();
         Assert.assertEquals(100, repository.insertBatch(entities));
     }
 
@@ -163,19 +164,19 @@ public abstract class BasicCommonTests {
     public void testInsertDuplicate() {
         //10次insert
         Assert.assertEquals(3, repository.insertBatch(
-                Stream
-                        .of(1, 2, 2, 3, 1, 3)
-                        .map(integer -> BasicTestEntity
-                                .builder()
-                                .id("test_dup_" + integer)
-                                .balance(1000L)
-                                .name("test2:" + integer)
-                                .createTime(new Date())
-                                .tags(Arrays.asList("a", "b", "c", "d"))
-                                .state((byte) 1)
-                                .stateEnum(StateEnum.enabled)
-                                .build())
-                        .collect(Collectors.toList())
+            Stream
+                .of(1, 2, 2, 3, 1, 3)
+                .map(integer -> BasicTestEntity
+                    .builder()
+                    .id("test_dup_" + integer)
+                    .balance(1000L)
+                    .name("test2:" + integer)
+                    .createTime(new Date())
+                    .tags(Arrays.asList("a", "b", "c", "d"))
+                    .state((byte) 1)
+                    .stateEnum(StateEnum.enabled)
+                    .build())
+                .collect(Collectors.toList())
         ));
         ;
 
@@ -186,31 +187,76 @@ public abstract class BasicCommonTests {
     }
 
     @Test
+    public void testRepositoryBatchSave() {
+        BasicTestEntity e1 = BasicTestEntity
+            .builder()
+            .id("test_id_batch_save")
+//            .balance(1000L)
+            .name("test")
+//            .createTime(new Date())
+            .tags(Arrays.asList("a", "b", "c", "d"))
+            .state((byte) 1)
+//            .addressId("test")
+//            .stateEnum(StateEnum.enabled)
+//            .enabled(true)
+            .build();
+
+        BasicTestEntity e2 = BasicTestEntity
+            .builder()
+            .id("test_id_batch_save_2")
+//            .balance(1000L)
+            .name("test")
+//            .createTime(new Date())
+            .tags(null)
+            .state((byte) 1)
+//            .addressId("test")
+//            .stateEnum(StateEnum.enabled)
+//            .enabled(true)
+            .build();
+
+
+        Assert.assertEquals(2, repository.save(e1, e2).getTotal());
+
+        getSqlExecutor()
+            .select("select * from entity_test_table where id in(?,?)",e1.getId(),e2.getId())
+            .forEach(System.out::println);
+
+        repository
+            .createQuery()
+            .select("id","tags")
+            .where()
+            .in("id", Arrays.asList(e1.getId(), e2.getId()))
+            .fetch()
+            .forEach(System.out::println);
+
+    }
+
+    @Test
     public void testRepositorySave() {
         BasicTestEntity entity = BasicTestEntity
-                .builder()
-                .id("test_id_save")
-                .balance(1000L)
-                .name("test")
-                .createTime(new Date())
-                .tags(Arrays.asList("a", "b", "c", "d"))
-                .state((byte) 1)
+            .builder()
+            .id("test_id_save")
+            .balance(1000L)
+            .name("test")
+            .createTime(new Date())
+            .tags(Arrays.asList("a", "b", "c", "d"))
+            .state((byte) 1)
 //                .aTest("test")
-                .addressId("test")
-                .doubleVal(1D)
-                .bigDecimal(new BigDecimal("1.2"))
-                .stateEnum(StateEnum.enabled)
-                .stateEnums(new StateEnum[]{StateEnum.enabled})
-                .build();
+            .addressId("test")
+            .doubleVal(1D)
+            .bigDecimal(new BigDecimal("1.2"))
+            .stateEnum(StateEnum.enabled)
+            .stateEnums(new StateEnum[]{StateEnum.enabled})
+            .build();
 
         Assert.assertEquals(repository.save(entity).getTotal(), 1);
         {
             BasicTestEntity inBase = repository
-                    .createQuery()
-                    .select("*")
-                    .where("id", entity.getId())
-                    .fetchOne()
-                    .orElseThrow(UnsupportedOperationException::new);
+                .createQuery()
+                .select("*")
+                .where("id", entity.getId())
+                .fetchOne()
+                .orElseThrow(UnsupportedOperationException::new);
 
             Assert.assertEquals(entity, inBase);
 
@@ -220,11 +266,11 @@ public abstract class BasicCommonTests {
         Assert.assertEquals(repository.save(entity).getTotal(), 1);
 
         BasicTestEntity inBase = repository
-                .createQuery()
-                .select("*")
-                .where("id", entity.getId())
-                .fetchOne()
-                .orElseThrow(UnsupportedOperationException::new);
+            .createQuery()
+            .select("*")
+            .where("id", entity.getId())
+            .fetchOne()
+            .orElseThrow(UnsupportedOperationException::new);
 
         Assert.assertEquals(StateEnum.enabled, inBase.getStateEnum());
 
@@ -234,48 +280,48 @@ public abstract class BasicCommonTests {
     @Test
     public void testEnums() {
         BasicTestEntity entity = BasicTestEntity
-                .builder()
-                .id("enums_id")
-                .balance(1000L)
-                .name("test")
-                .createTime(new Date())
-                .tags(Arrays.asList("a", "b", "c", "d"))
-                .state((byte) 1)
-                .addressId("test")
-                .stateEnum(StateEnum.enabled)
-                .stateEnums(new StateEnum[]{StateEnum.enabled, StateEnum.disabled})
-                .build();
+            .builder()
+            .id("enums_id")
+            .balance(1000L)
+            .name("test")
+            .createTime(new Date())
+            .tags(Arrays.asList("a", "b", "c", "d"))
+            .state((byte) 1)
+            .addressId("test")
+            .stateEnum(StateEnum.enabled)
+            .stateEnums(new StateEnum[]{StateEnum.enabled, StateEnum.disabled})
+            .build();
         repository.insert(entity);
 
 
         Assert.assertFalse(repository
-                                   .createQuery()
-                                   .select("id", "stateEnums")
-                                   .in(BasicTestEntity::getStateEnums, StateEnum.enabled)
-                                   .fetchOne()
-                                   .isPresent());
+                               .createQuery()
+                               .select("id", "stateEnums")
+                               .in(BasicTestEntity::getStateEnums, StateEnum.enabled)
+                               .fetchOne()
+                               .isPresent());
 
         Assert.assertTrue(repository
-                                  .createQuery()
-                                  .select("id", "stateEnums")
-                                  .in(BasicTestEntity::getStateEnums, StateEnum.enabled, StateEnum.disabled)
-                                  .fetchOne()
-                                  .isPresent());
+                              .createQuery()
+                              .select("id", "stateEnums")
+                              .in(BasicTestEntity::getStateEnums, StateEnum.enabled, StateEnum.disabled)
+                              .fetchOne()
+                              .isPresent());
 
         Assert.assertTrue(repository
-                                  .createQuery()
-                                  .select("id", "stateEnums")
-                                  .where(Terms.enumInAny(BasicTestEntity::getStateEnums, StateEnum.disabled))
-                                  .fetchOne()
-                                  .isPresent());
+                              .createQuery()
+                              .select("id", "stateEnums")
+                              .where(Terms.enumInAny(BasicTestEntity::getStateEnums, StateEnum.disabled))
+                              .fetchOne()
+                              .isPresent());
 
 
         Assert.assertTrue(repository
-                                  .createQuery()
-                                  .select("id", "stateEnums")
-                                  .where(Terms.enumNotInAny(BasicTestEntity::getStateEnums, StateEnum.warn))
-                                  .fetchOne()
-                                  .isPresent());
+                              .createQuery()
+                              .select("id", "stateEnums")
+                              .where(Terms.enumNotInAny(BasicTestEntity::getStateEnums, StateEnum.warn))
+                              .fetchOne()
+                              .isPresent());
 
     }
 
@@ -284,16 +330,16 @@ public abstract class BasicCommonTests {
     public void testJoin() {
 
         BasicTestEntity entity = BasicTestEntity
-                .builder()
-                .id("joinTest")
-                .balance(1000L)
-                .name("test")
-                .createTime(new Date())
-                .tags(Arrays.asList("a", "b", "c", "d"))
-                .state((byte) 1)
-                .addressId("joinTest")
-                .stateEnum(StateEnum.enabled)
-                .build();
+            .builder()
+            .id("joinTest")
+            .balance(1000L)
+            .name("test")
+            .createTime(new Date())
+            .tags(Arrays.asList("a", "b", "c", "d"))
+            .state((byte) 1)
+            .addressId("joinTest")
+            .stateEnum(StateEnum.enabled)
+            .build();
         addressRepository.insert(Record.newRecord().putValue("id", "joinTest").putValue("name", "joinTest"));
         repository.insert(entity);
 
@@ -309,16 +355,16 @@ public abstract class BasicCommonTests {
 
 
         BasicTestEntity entity = BasicTestEntity
-                .builder()
-                .id("test_id")
-                .balance(1000L)
-                .name("test")
-                .createTime(new Date())
-                .tags(Arrays.asList("a", "b", "c", "d"))
-                .state((byte) 1)
-                .addressId("test")
-                .stateEnum(StateEnum.enabled)
-                .build();
+            .builder()
+            .id("test_id")
+            .balance(1000L)
+            .name("test")
+            .createTime(new Date())
+            .tags(Arrays.asList("a", "b", "c", "d"))
+            .state((byte) 1)
+            .addressId("test")
+            .stateEnum(StateEnum.enabled)
+            .build();
         addressRepository.insert(Record.newRecord().putValue("id", "test").putValue("name", "test_address"));
         repository.insert(entity);
 
@@ -392,9 +438,9 @@ public abstract class BasicCommonTests {
         } finally {
             try {
                 operator
-                        .sql()
-                        .sync()
-                        .execute(SqlRequests.of("drop table " + database.getCurrentSchema().getName() + ".test_pager"));
+                    .sql()
+                    .sync()
+                    .execute(SqlRequests.of("drop table " + database.getCurrentSchema().getName() + ".test_pager"));
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -454,11 +500,11 @@ public abstract class BasicCommonTests {
         } finally {
             try {
                 operator
-                        .sql()
-                        .sync()
-                        .execute(SqlRequests.of("drop table " + database
-                                .getCurrentSchema()
-                                .getName() + ".test_dml_crud"));
+                    .sql()
+                    .sync()
+                    .execute(SqlRequests.of("drop table " + database
+                        .getCurrentSchema()
+                        .getName() + ".test_dml_crud"));
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -512,11 +558,11 @@ public abstract class BasicCommonTests {
         } finally {
             try {
                 operator
-                        .sql()
-                        .sync()
-                        .execute(SqlRequests.of("drop table " + database
-                                .getCurrentSchema()
-                                .getName() + ".test_ddl_create"));
+                    .sql()
+                    .sync()
+                    .execute(SqlRequests.of("drop table " + database
+                        .getCurrentSchema()
+                        .getName() + ".test_ddl_create"));
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/BasicReactiveTests.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/BasicReactiveTests.java
@@ -359,6 +359,43 @@ public abstract class BasicReactiveTests {
 
     }
 
+    @Test
+    public void testReactiveRepositoryBatchSave() {
+        BasicTestEntity e1 = BasicTestEntity
+            .builder()
+            .id("test_id_batch_save")
+//            .balance(1000L)
+            .name("test")
+//            .createTime(new Date())
+            .tags(Arrays.asList("a", "b", "c", "d"))
+            .state((byte) 1)
+//            .addressId("test")
+//            .stateEnum(StateEnum.enabled)
+//            .enabled(true)
+            .build();
+
+        BasicTestEntity e2 = BasicTestEntity
+            .builder()
+            .id("test_id_batch_save_2")
+//            .balance(1000L)
+            .name("test")
+//            .createTime(new Date())
+            .tags(null)
+            .state((byte) 1)
+//            .addressId("test")
+//            .stateEnum(StateEnum.enabled)
+//            .enabled(true)
+            .build();
+
+
+        repository.save(Flux.just(e1, e2))
+                  .map(SaveResult::getTotal)
+                  .as(StepVerifier::create)
+                  .expectNext(2)
+                  .verifyComplete();
+
+
+    }
 
     @Test
     public void testReactiveRepositorySave() {

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleConnectionProvider.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleConnectionProvider.java
@@ -23,25 +23,23 @@ public class OracleConnectionProvider implements ConnectionProvider {
     static {
         try {
             Class.forName("oracle.jdbc.driver.OracleDriver");
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-        }
-        GenericContainer<?> container = Containers.newOracle();
 
-        container.start();
-        port = container.getMappedPort(1521);
+            GenericContainer<?> container = Containers.newOracle();
 
-        String username = System.getProperty("oracle.username", "system");
-        String password = System.getProperty("oracle.password", "oracle");
-        String url = System.getProperty("oracle.url", "127.0.0.1:" + port);
-        String db = System.getProperty("oracle.db", "orcl");
-        connectionSupplier = () -> DriverManager.getConnection("jdbc:oracle:thin:@" + url + ":" + db, username, password);
-        for (int i = 0; i < 10; i++) {
-            try {
+            container.start();
+            port = container.getMappedPort(1521);
+
+            String username = System.getProperty("oracle.username", "system");
+            String password = System.getProperty("oracle.password", "oracle");
+            String url = System.getProperty("oracle.url", "127.0.0.1:" + port);
+            String db = System.getProperty("oracle.db", "orcl");
+            connectionSupplier = () -> DriverManager.getConnection("jdbc:oracle:thin:@" + url + ":" + db, username, password);
+            for (int i = 0; i < 10; i++) {
                 connectionQueue.add(connectionSupplier.call());
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+
             }
+        } catch (Throwable e) {
+            e.printStackTrace();
         }
     }
 

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleR2dbcConnectionProvider.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleR2dbcConnectionProvider.java
@@ -33,15 +33,16 @@ public class OracleR2dbcConnectionProvider implements R2dbcConnectionProvider {
 
         URL hostUrl = new URL("file://" + url);
 
-        connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions
-                                                            .builder()
-                                                            .option(DRIVER, "oracle")
-                                                            .option(HOST, hostUrl.getHost())
-                                                            .option(PORT, hostUrl.getPort())
-                                                            .option(USER, username)
-                                                            .option(PASSWORD, password)
-                                                            .option(DATABASE, db)
-                                                            .build());
+        connectionFactory = ConnectionFactories
+            .get(ConnectionFactoryOptions
+                     .builder()
+                     .option(DRIVER, "oracle")
+                     .option(HOST, hostUrl.getHost())
+                     .option(PORT, hostUrl.getPort())
+                     .option(USER, username)
+                     .option(PASSWORD, password)
+                     .option(DATABASE, db)
+                     .build());
 
         connectionSupplier = Mono.from(connectionFactory.create());
 

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleReactiveTests.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/oracle/OracleReactiveTests.java
@@ -36,7 +36,7 @@ public class OracleReactiveTests extends BasicReactiveTests {
     protected ReactiveSqlExecutor getSqlExecutor() {
 
         return new TestJdbcReactiveSqlExecutor(new OracleConnectionProvider());
-
+//
 //        return new TestReactiveSqlExecutor(":",new OracleR2dbcConnectionProvider()){
 //            @Override
 //            protected void bindNull(Statement statement, int index, Class type) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make CLOB encoding/decoding and null handling column-aware, replacing ClobValue with LongCharSequence and updating executors/builders (incl. Oracle) and tests accordingly.
> 
> - **Core**:
>   - Add column-aware `ValueCodec.encodeNull(ColumnMetadata)` and use it in `AbstractColumnMetadata` and `rdb/metadata/RDBColumnMetadata`.
> - **RDB Codecs**:
>   - `ClobValueCodec`: add `isClobType`, return `NullValue` for column-aware nulls, wrap CLOB text as `LongCharSequence`.
>   - `JsonValueCodec`: use column-aware nulls and `LongCharSequence` for CLOB columns; expand decode support (e.g., `Reader`, typed blobs) and handle null targets.
>   - New `LongCharSequence` replaces prior CLOB wrapper; used for streaming/Clob binding.
>   - `NullValue`: store explicit `type`, improve `getType()` and `toString()`, add `of(DataType)` helper.
> - **Executors**:
>   - JDBC: bind `LongCharSequence` via `setCharacterStream`; honor `NullValue` SQL types.
>   - R2DBC: bind `LongCharSequence` as `Clob`; bind `NullValue` by Java type, special-case CLOB nulls.
> - **Oracle SQL Builders**:
>   - `OracleBatchUpsertOperator` and `OracleInsertSqlBuilder`: encode values per column; for batched CLOB nulls, substitute empty `LongCharSequence` to avoid null binding.
> - **Tests/Infra**:
>   - Add batch save tests (sync/reactive) and adjust Oracle connection providers; minor test formatting tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e43d63cca54ba22f3c5b744b2100d41e55a1fb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->