### PR TITLE
feat: 新增Kingbase-Mysql支持

### DIFF
--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/metadata/dialect/Dialect.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/metadata/dialect/Dialect.java
@@ -7,6 +7,7 @@ import org.hswebframework.ezorm.rdb.metadata.RDBFeatureType;
 import org.hswebframework.ezorm.rdb.operator.builder.fragments.SqlFragments;
 import org.hswebframework.ezorm.rdb.operator.builder.fragments.term.EnumInFragmentBuilder;
 import org.hswebframework.ezorm.rdb.supports.h2.H2Dialect;
+import org.hswebframework.ezorm.rdb.supports.kingbase.mysql.KingbaseMysqlDialect;
 import org.hswebframework.ezorm.rdb.supports.mssql.SqlServerDialect;
 import org.hswebframework.ezorm.rdb.supports.mysql.MysqlDialect;
 import org.hswebframework.ezorm.rdb.supports.oracle.OracleDialect;
@@ -94,5 +95,6 @@ public interface Dialect extends Feature {
     Dialect H2 = new H2Dialect();
     Dialect MSSQL = new SqlServerDialect();
     Dialect POSTGRES = new PostgresqlDialect();
+    Dialect KINGBASE_MYSQL = new KingbaseMysqlDialect();
 
 }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlBatchUpsertOperator.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlBatchUpsertOperator.java
@@ -1,0 +1,23 @@
+package org.hswebframework.ezorm.rdb.supports.kingbase.mysql;
+
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlBatchUpsertOperator;
+
+/**
+ * KingbaseES MySQL 兼容模式的批量 Upsert 操作器.
+ * <p>
+ * KingbaseES MySQL 兼容版完全支持 {@code ON DUPLICATE KEY UPDATE} 语法，
+ * 因此直接继承 {@link MysqlBatchUpsertOperator}，不做任何修改。
+ * <p>
+ * 如果后续发现语法差异，可在此类中覆盖对应方法。
+ *
+ * @since 4.2
+ */
+@SuppressWarnings("all")
+public class KingbaseMysqlBatchUpsertOperator extends MysqlBatchUpsertOperator {
+
+    public KingbaseMysqlBatchUpsertOperator(RDBTableMetadata table) {
+        super(table);
+    }
+
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlCreateTableSqlBuilder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlCreateTableSqlBuilder.java
@@ -1,0 +1,89 @@
+package org.hswebframework.ezorm.rdb.supports.kingbase.mysql;
+
+import org.hswebframework.ezorm.core.DefaultValue;
+import org.hswebframework.ezorm.core.utils.StringUtils;
+import org.hswebframework.ezorm.rdb.executor.DefaultBatchSqlRequest;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBIndexMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.PrepareSqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.ddl.CreateIndexParameter;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.ddl.CreateIndexSqlBuilder;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.ddl.CreateTableSqlBuilder;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlCreateTableSqlBuilder;
+
+/**
+ * KingbaseES MySQL 兼容模式的建表 SQL 构建器.
+ * <p>
+ * 与 {@link MysqlCreateTableSqlBuilder} 的区别：
+ * <ul>
+ *   <li>去掉了 {@code ENGINE=InnoDB DEFAULT CHARSET=utf8mb4} 等 MySQL 特有子句</li>
+ *   <li>保留了 {@code auto_increment}（KingbaseES MySQL 兼容版支持）</li>
+ *   <li>保留了 {@code comment} 语法</li>
+ * </ul>
+ *
+ * @since 4.2
+ */
+@SuppressWarnings("all")
+public class KingbaseMysqlCreateTableSqlBuilder implements CreateTableSqlBuilder {
+
+    @Override
+    public SqlRequest build(RDBTableMetadata table) {
+        DefaultBatchSqlRequest sql = new DefaultBatchSqlRequest();
+
+        PrepareSqlFragments createTable = PrepareSqlFragments.of();
+
+        createTable.addSql("create table", table.getFullName(), "(");
+
+        int index = 0;
+        for (RDBColumnMetadata column : table.getColumns()) {
+            if (index++ != 0) {
+                createTable.addSql(",");
+            }
+            createTable.addSql(column.getQuoteName());
+            if (column.getColumnDefinition() != null) {
+                createTable.addSql(column.getColumnDefinition());
+            } else {
+                createTable.addSql(column.getDialect().buildColumnDataType(column));
+                if (column.isNotNull() || column.isPrimaryKey()) {
+                    createTable.addSql("not null");
+                }
+                if (column.isPrimaryKey()) {
+                    createTable.addSql("primary key");
+                }
+                if (column.isAutoIncrement()) {
+                    createTable.addSql("auto_increment");
+                } else {
+                    DefaultValue defaultValue = column.getDefaultValue();
+                    if (defaultValue instanceof NativeSql) {
+                        createTable.addSql("default", ((NativeSql) defaultValue).getSql());
+                    }
+                }
+                if (column.getComment() != null) {
+                    createTable.addSql(" comment ",
+                                       StringUtils.concat("'", column.getComment(), "'"));
+                }
+            }
+        }
+
+        // KingbaseES 不支持 ENGINE= 和 DEFAULT CHARSET=，直接关闭括号
+        createTable.addSql(")");
+
+        if (table.getComment() != null) {
+            createTable.addSql("COMMENT=", StringUtils.concat("'", table.getComment(), "'"));
+        }
+
+        sql.setSql(createTable.toRequest().getSql());
+
+        table.findFeature(CreateIndexSqlBuilder.ID)
+                .ifPresent(builder -> {
+                    for (RDBIndexMetadata tableIndex : table.getIndexes()) {
+                        sql.addBatch(builder.build(CreateIndexParameter.of(table, tableIndex)));
+                    }
+                });
+
+        return sql;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlDialect.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlDialect.java
@@ -1,0 +1,91 @@
+package org.hswebframework.ezorm.rdb.supports.kingbase.mysql;
+
+import org.hswebframework.ezorm.core.utils.StringUtils;
+import org.hswebframework.ezorm.rdb.metadata.DataType;
+import org.hswebframework.ezorm.rdb.metadata.JdbcDataType;
+import org.hswebframework.ezorm.rdb.metadata.dialect.DefaultDialect;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+
+import java.sql.Date;
+import java.sql.JDBCType;
+
+/**
+ * KingbaseES MySQL 兼容模式方言.
+ * <p>
+ * KingbaseES MySQL 兼容版在 SQL 语法层面兼容 MySQL，但底层使用 PostgreSQL 协议通信。
+ * 因此：
+ * <ul>
+ *   <li>数据类型映射：复用 MySQL 的类型映射</li>
+ *   <li>标识符引用：使用双引号（PostgreSQL 风格），因为驱动层是 r2dbc-postgresql</li>
+ * </ul>
+ *
+ * @since 4.2
+ */
+public class KingbaseMysqlDialect extends DefaultDialect {
+
+    public static final Dialect global = new KingbaseMysqlDialect();
+
+    public KingbaseMysqlDialect() {
+        super();
+        // 复用 MySQL 的数据类型映射
+        addDataTypeBuilder(JDBCType.CHAR, (meta) -> StringUtils.concat("char(", meta.getLength(), ")"));
+        addDataTypeBuilder(JDBCType.VARCHAR, (meta) -> StringUtils.concat("varchar(", meta.getLength(), ")"));
+        addDataTypeBuilder(JDBCType.NVARCHAR, (meta) -> StringUtils.concat("nvarchar(", meta.getLength(), ")"));
+
+        addDataTypeBuilder(JDBCType.TIMESTAMP, (meta) -> "datetime(" + Math.min(6, meta.getLength()) + ")");
+        addDataTypeBuilder(JDBCType.TIME, (meta) -> "time");
+        addDataTypeBuilder(JDBCType.DATE, (meta) -> "date");
+        addDataTypeBuilder(JDBCType.CLOB, (meta) -> "text");
+        addDataTypeBuilder(JDBCType.LONGVARBINARY, (meta) -> "blob");
+        addDataTypeBuilder(JDBCType.LONGVARCHAR, (meta) -> "longtext");
+        addDataTypeBuilder(JDBCType.BLOB, (meta) -> "blob");
+        addDataTypeBuilder(JDBCType.BIGINT, (meta) -> "bigint");
+        addDataTypeBuilder(JDBCType.DOUBLE, (meta) -> "double");
+        addDataTypeBuilder(JDBCType.INTEGER, (meta) -> "int");
+        addDataTypeBuilder(JDBCType.NUMERIC, (meta) -> StringUtils.concat("decimal(", meta.getPrecision(32), ",", meta.getScale(), ")"));
+        addDataTypeBuilder(JDBCType.DECIMAL, (meta) -> StringUtils.concat("decimal(", meta.getPrecision(32), ",", meta.getScale(), ")"));
+        addDataTypeBuilder(JDBCType.TINYINT, (meta) -> "tinyint");
+        addDataTypeBuilder(JDBCType.BOOLEAN, (meta) -> "tinyint");
+        addDataTypeBuilder(JDBCType.BIGINT, (meta) -> "bigint");
+        addDataTypeBuilder(JDBCType.OTHER, (meta) -> "other");
+        addDataTypeBuilder(JDBCType.LONGNVARCHAR, (meta) -> "text");
+
+        addDataTypeBuilder("int", (meta) -> "int");
+        addDataTypeBuilder("json", meta -> "json");
+
+        registerDataType("clob", DataType.builder(JdbcDataType.of(JDBCType.CLOB, String.class), c -> "text"));
+        registerDataType("longnvarchar", DataType.builder(JdbcDataType.of(JDBCType.LONGNVARCHAR, String.class), c -> "longtext"));
+        registerDataType("longvarchar", DataType.builder(JdbcDataType.of(JDBCType.LONGVARCHAR, String.class), c -> "longtext"));
+
+        registerDataType("int", JdbcDataType.of(JDBCType.INTEGER, Integer.class));
+        registerDataType("text", JdbcDataType.of(JDBCType.CLOB, String.class));
+        registerDataType("longtext", JdbcDataType.of(JDBCType.LONGVARCHAR, String.class));
+        registerDataType("year", JdbcDataType.of(JDBCType.DATE, Date.class));
+        registerDataType("datetime", JdbcDataType.of(JDBCType.TIMESTAMP, Date.class));
+    }
+
+    @Override
+    public String getQuoteStart() {
+        return "\"";
+    }
+
+    @Override
+    public String getQuoteEnd() {
+        return "\"";
+    }
+
+    @Override
+    public boolean isColumnToUpperCase() {
+        return false;
+    }
+
+    @Override
+    public String getId() {
+        return "kingbase-mysql";
+    }
+
+    @Override
+    public String getName() {
+        return "KingBase(MySQL)";
+    }
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlSchemaMetadata.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlSchemaMetadata.java
@@ -1,0 +1,71 @@
+package org.hswebframework.ezorm.rdb.supports.kingbase.mysql;
+
+import org.hswebframework.ezorm.rdb.codec.EnumValueCodec;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.operator.CompositeExceptionTranslation;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlAlterTableSqlBuilder;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlEnumInFragmentBuilder;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlIndexMetadataParser;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlPaginator;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlR2DBCExceptionTranslation;
+import org.hswebframework.ezorm.rdb.utils.FeatureUtils;
+
+/**
+ * KingbaseES MySQL 兼容模式的 Schema 元数据.
+ * <p>
+ * KingbaseES 底层使用 PostgreSQL 协议通信，但 SQL 语法兼容 MySQL。因此：
+ * <ul>
+ *   <li>DDL 构建器：使用 KingbaseES 适配版（去掉 ENGINE=/CHARSET=）</li>
+ *   <li>分页器：复用 MySQL 的 LIMIT ?,? 语法</li>
+ *   <li>元数据解析器：复用 MySQL information_schema 查询</li>
+ *   <li>异常翻译：使用 <b>PostgreSQL</b> 异常翻译（因为驱动层是 r2dbc-postgresql）</li>
+ *   <li>方言：使用 {@link KingbaseMysqlDialect}（MySQL 类型映射 + 双引号引用）</li>
+ * </ul>
+ *
+ * @since 4.2
+ */
+public class KingbaseMysqlSchemaMetadata extends RDBSchemaMetadata {
+
+    public KingbaseMysqlSchemaMetadata(String name) {
+        super(name);
+
+        // DDL 构建器 - 去掉 ENGINE=/CHARSET=
+        addFeature(new KingbaseMysqlCreateTableSqlBuilder());
+        addFeature(new MysqlAlterTableSqlBuilder());
+
+        // 分页器 - 复用 MySQL 的 LIMIT ?,? 语法
+        addFeature(new MysqlPaginator());
+
+        // 元数据解析器
+        addFeature(new KingbaseMysqlTableMetadataParser(this));
+        addFeature(new MysqlIndexMetadataParser(this));
+
+        // 方言
+        addFeature(KingbaseMysqlDialect.global);
+
+        // 异常翻译 - 使用 PostgreSQL（因为底层是 PG 协议驱动）
+        addFeature(new CompositeExceptionTranslation()
+                           .add(FeatureUtils.r2dbcIsAlive(), () -> PostgresqlR2DBCExceptionTranslation.of(this))
+        );
+    }
+
+    @Override
+    public RDBTableMetadata newTable(String name) {
+        RDBTableMetadata metadata = super.newTable(name);
+        metadata.addFeature(new KingbaseMysqlBatchUpsertOperator(metadata));
+        metadata.setOnColumnAdded(column -> {
+            if (column.getValueCodec() instanceof EnumValueCodec && ((EnumValueCodec) column.getValueCodec()).isToMask()) {
+                column.addFeature(MysqlEnumInFragmentBuilder.in);
+                column.addFeature(MysqlEnumInFragmentBuilder.notIn);
+            }
+        });
+        return metadata;
+    }
+
+    @Override
+    public void addTable(RDBTableMetadata metadata) {
+        metadata.addFeature(new KingbaseMysqlBatchUpsertOperator(metadata));
+        super.addTable(metadata);
+    }
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlTableMetadataParser.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlTableMetadataParser.java
@@ -1,0 +1,24 @@
+package org.hswebframework.ezorm.rdb.supports.kingbase.mysql;
+
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlTableMetadataParser;
+
+/**
+ * KingbaseES MySQL 兼容模式的表元数据解析器.
+ * <p>
+ * KingbaseES MySQL 兼容模式的 {@code information_schema.columns} 和
+ * {@code information_schema.tables} 与 MySQL 高度兼容，
+ * 因此直接继承 {@link MysqlTableMetadataParser}。
+ * <p>
+ * 如果后续发现字段差异（如 {@code column_type} 不存在等），
+ * 可在此类中覆盖对应的 SQL 方法。
+ *
+ * @since 4.2
+ */
+public class KingbaseMysqlTableMetadataParser extends MysqlTableMetadataParser {
+
+    public KingbaseMysqlTableMetadataParser(RDBSchemaMetadata schema) {
+        super(schema);
+    }
+
+}


### PR DESCRIPTION
需求：支持 KingbaseES MySQL 兼容模式
核心发现：KingbaseES MySQL 兼容版 = PostgreSQL 协议 + MySQL SQL 语法
改动范围：新增 5 个文件 + 修改 Dialect.java 1 行
已验证：在 JetLinks 中连接 KingbaseES MySQL 兼容版测试通过
特殊说明:  使用jdk8基于master分支修改后进行的测试, 不涉及jdk17语法, 请审核后决定是否合并到4.2分支
配置方式
```yml
easyorm:
  dialect: kingbase_mysql
  default-schema: your_schema

spring:
  r2dbc:
    url: r2dbc:postgresql://kingbase-host:54321/your_database
    username: your_user
    password: your_password
```
