### PR TITLE
feat(PostgreSQL): 增加数组类型字段支持

### DIFF
--- a/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/Conditional.java
+++ b/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/Conditional.java
@@ -870,6 +870,132 @@ public interface Conditional<T extends Conditional<?>> extends LogicalOperation<
     }
 
     /**
+     * 追加包含条件（静态方法引用方式）: column contains ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前条件构造器
+     */
+    default <B> T contains(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.contains, value);
+    }
+
+    /**
+     * 追加包含条件（方法引用方式）: column contains ?
+     *
+     * @param column 列引用
+     * @return 当前条件构造器
+     */
+    default <B> T contains(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.contains);
+    }
+
+    /**
+     * 追加不包含条件（静态方法引用方式）: column not contains ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前条件构造器
+     */
+    default <B> T notContains(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.ncontains, value);
+    }
+
+    /**
+     * 追加不包含条件（方法引用方式）: column not contains ?
+     *
+     * @param column 列引用
+     * @return 当前条件构造器
+     */
+    default <B> T notContains(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.ncontains);
+    }
+
+    /**
+     * 追加被包含条件（静态方法引用方式）: column contained by ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前条件构造器
+     */
+    default <B> T contained(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.contained, value);
+    }
+
+    /**
+     * 追加被包含条件（方法引用方式）: column contained by ?
+     *
+     * @param column 列引用
+     * @return 当前条件构造器
+     */
+    default <B> T contained(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.contained);
+    }
+
+    /**
+     * 追加不被包含条件（静态方法引用方式）: column not contained by ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前条件构造器
+     */
+    default <B> T notContained(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.ncontained, value);
+    }
+
+    /**
+     * 追加不被包含条件（方法引用方式）: column not contained by ?
+     *
+     * @param column 列引用
+     * @return 当前条件构造器
+     */
+    default <B> T notContained(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.ncontained);
+    }
+
+    /**
+     * 追加相交条件（静态方法引用方式）: column overlap ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前条件构造器
+     */
+    default <B> T overlap(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.overlap, value);
+    }
+
+    /**
+     * 追加相交条件（方法引用方式）: column overlap ?
+     *
+     * @param column 列引用
+     * @return 当前条件构造器
+     */
+    default <B> T overlap(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.overlap);
+    }
+
+    /**
+     * 追加不相交条件（静态方法引用方式）: column not overlap ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前条件构造器
+     */
+    default <B> T notOverlap(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.noverlap, value);
+    }
+
+    /**
+     * 追加不相交条件（方法引用方式）: column not overlap ?
+     *
+     * @param column 列引用
+     * @return 当前条件构造器
+     */
+    default <B> T notOverlap(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.noverlap);
+    }
+
+    /**
      * 追加为空条件（静态方法引用方式）: column = ''
      *
      * @param column 列引用

--- a/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/NestConditional.java
+++ b/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/NestConditional.java
@@ -686,6 +686,132 @@ public interface NestConditional<T extends TermTypeConditionalSupport> extends L
     }
 
     /**
+     * 追加包含条件（方法引用方式）: column contains ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> contains(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.contains, value);
+    }
+
+    /**
+     * 追加包含条件（方法引用方式）: column contains ?
+     *
+     * @param column 列引用
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> contains(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.contains);
+    }
+
+    /**
+     * 追加不包含条件（方法引用方式）: column not contains ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> notContains(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.ncontains, value);
+    }
+
+    /**
+     * 追加不包含条件（方法引用方式）: column not contains ?
+     *
+     * @param column 列引用
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> notContains(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.ncontains);
+    }
+
+    /**
+     * 追加被包含条件（方法引用方式）: column contained by ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> contained(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.contained, value);
+    }
+
+    /**
+     * 追加被包含条件（方法引用方式）: column contained by ?
+     *
+     * @param column 列引用
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> contained(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.contained);
+    }
+
+    /**
+     * 追加不被包含条件（方法引用方式）: column not contained by ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> notContained(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.ncontained, value);
+    }
+
+    /**
+     * 追加不被包含条件（方法引用方式）: column not contained by ?
+     *
+     * @param column 列引用
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> notContained(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.ncontained);
+    }
+
+    /**
+     * 追加相交条件（方法引用方式）: column overlap ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> overlap(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.overlap, value);
+    }
+
+    /**
+     * 追加相交条件（方法引用方式）: column overlap ?
+     *
+     * @param column 列引用
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> overlap(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.overlap);
+    }
+
+    /**
+     * 追加不相交条件（方法引用方式）: column not overlap ?
+     *
+     * @param column 列引用
+     * @param value  条件值
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> notOverlap(StaticMethodReferenceColumn<B> column, Object value) {
+        return accept(column, TermType.noverlap, value);
+    }
+
+    /**
+     * 追加不相交条件（方法引用方式）: column not overlap ?
+     *
+     * @param column 列引用
+     * @return 当前嵌套条件构造器
+     */
+    default <B> NestConditional<T> notOverlap(MethodReferenceColumn<B> column) {
+        return accept(column, TermType.noverlap);
+    }
+
+    /**
      * 追加为空条件（方法引用方式）: column = '' or column is null
      * 
      * @param column 列引用

--- a/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/param/TermType.java
+++ b/hsweb-easy-orm-core/src/main/java/org/hswebframework/ezorm/core/param/TermType.java
@@ -120,4 +120,46 @@ public interface TermType {
      */
     String nbtw    = "nbtw";
 
+    /**
+     * contains
+     *
+     * @since 4.2
+     */
+    String contains = "contains";
+
+    /**
+     * not contains
+     *
+     * @since 4.2
+     */
+    String ncontains = "ncontains";
+
+    /**
+     * contained by
+     *
+     * @since 4.2
+     */
+    String contained = "contained";
+
+    /**
+     * not contained by
+     *
+     * @since 4.2
+     */
+    String ncontained = "ncontained";
+
+    /**
+     * overlap
+     *
+     * @since 4.2
+     */
+    String overlap = "overlap";
+
+    /**
+     * not overlap
+     *
+     * @since 4.2
+     */
+    String noverlap = "noverlap";
+
 }

--- a/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/dsl/QueryTest.java
+++ b/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/dsl/QueryTest.java
@@ -55,6 +55,16 @@ public class QueryTest {
             assertSingleCondition(query -> query.in(TestEntity::getId, Arrays.asList(1, 2, 3)), "in",  Arrays.asList(1, 2, 3));
         }
 
+        //array-like terms
+        {
+            assertSingleCondition(query -> query.contains(TestEntity::getId, 1), "contains", 1);
+            assertSingleCondition(query -> query.notContains(TestEntity::getId, 1), "ncontains", 1);
+            assertSingleCondition(query -> query.contained(TestEntity::getId, 1), "contained", 1);
+            assertSingleCondition(query -> query.notContained(TestEntity::getId, 1), "ncontained", 1);
+            assertSingleCondition(query -> query.overlap(TestEntity::getId, 1), "overlap", 1);
+            assertSingleCondition(query -> query.notOverlap(TestEntity::getId, 1), "noverlap", 1);
+        }
+
         //gt lt
         {
             assertSingleCondition(query -> query.gt(TestEntity::getId, 1), "gt", 1);

--- a/hsweb-easy-orm-rdb/pom.xml
+++ b/hsweb-easy-orm-rdb/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.17.1</version>
+            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/JdbcParameterBinder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/JdbcParameterBinder.java
@@ -1,0 +1,9 @@
+package org.hswebframework.ezorm.rdb.executor;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface JdbcParameterBinder {
+
+    void bind(PreparedStatement statement, int index) throws SQLException;
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/R2dbcParameterBinder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/R2dbcParameterBinder.java
@@ -1,0 +1,8 @@
+package org.hswebframework.ezorm.rdb.executor;
+
+import io.r2dbc.spi.Statement;
+
+public interface R2dbcParameterBinder {
+
+    void bind(Statement statement, String identifier);
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutorHelper.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutorHelper.java
@@ -2,6 +2,7 @@ package org.hswebframework.ezorm.rdb.executor.jdbc;
 
 import lombok.SneakyThrows;
 import org.hswebframework.ezorm.rdb.codec.LongCharSequence;
+import org.hswebframework.ezorm.rdb.executor.JdbcParameterBinder;
 import org.hswebframework.ezorm.rdb.executor.NullValue;
 
 import java.io.ByteArrayInputStream;
@@ -37,6 +38,8 @@ public class JdbcSqlExecutorHelper {
         for (Object object : parameter) {
             if (object == null) {
                 statement.setNull(index++, Types.NULL);
+            } else if (object instanceof JdbcParameterBinder binder) {
+                binder.bind(statement, index++);
             } else if (object instanceof NullValue nullValue) {
                 statement.setNull(index++, nullValue.getDataType().getSqlType().getVendorTypeNumber());
             } else if (object instanceof Date) {

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutorHelper.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutorHelper.java
@@ -41,7 +41,11 @@ public class JdbcSqlExecutorHelper {
             } else if (object instanceof JdbcParameterBinder binder) {
                 binder.bind(statement, index++);
             } else if (object instanceof NullValue nullValue) {
-                statement.setNull(index++, nullValue.getDataType().getSqlType().getVendorTypeNumber());
+                int sqlType = nullValue.getDataType().getSqlType().getVendorTypeNumber();
+                if (nullValue.getType() == LongCharSequence.class) {
+                    sqlType = Types.LONGVARCHAR;
+                }
+                statement.setNull(index++, sqlType);
             } else if (object instanceof Date) {
                 statement.setTimestamp(index++, new java.sql.Timestamp(((Date) object).getTime()));
             } else if (object instanceof byte[] b) {

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/reactive/r2dbc/R2dbcReactiveSqlExecutor.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/reactive/r2dbc/R2dbcReactiveSqlExecutor.java
@@ -9,6 +9,7 @@ import org.hswebframework.ezorm.rdb.codec.LongCharSequence;
 import org.hswebframework.ezorm.rdb.executor.BatchSqlRequest;
 import org.hswebframework.ezorm.rdb.executor.DefaultColumnWrapperContext;
 import org.hswebframework.ezorm.rdb.executor.NullValue;
+import org.hswebframework.ezorm.rdb.executor.R2dbcParameterBinder;
 import org.hswebframework.ezorm.rdb.executor.SqlRequest;
 import org.hswebframework.ezorm.rdb.executor.reactive.ReactiveSqlExecutor;
 import org.hswebframework.ezorm.rdb.executor.wrapper.ResultWrapper;
@@ -251,6 +252,8 @@ public abstract class R2dbcReactiveSqlExecutor implements ReactiveSqlExecutor {
         for (Object parameter : request.getParameters()) {
             if (parameter == null) {
                 bindNull(statement, index, String.class);
+            } else if (parameter instanceof R2dbcParameterBinder binder) {
+                binder.bind(statement, getBindSymbol() + (index + getBindFirstIndex()));
             } else if (parameter instanceof NullValue nullValue) {
                 Class<?> javaType = nullValue.getType();
                 if (javaType == LongCharSequence.class) {

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/insert/BatchInsertSqlBuilder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/insert/BatchInsertSqlBuilder.java
@@ -114,22 +114,26 @@ public class BatchInsertSqlBuilder implements InsertSqlBuilder {
             int indexSize = primaryIndex.size();
             int vSize = values.size();
 
-            if(shoudCheckDumplicateKey(primaryIndex,values)){
+            if (shoudCheckDumplicateKey(primaryIndex, values)) {
                 // id
                 if (indexSize == 1) {
                     int idx = primaryIndex.get(0);
-                    Object idValue = values.get(idx);
-                    if (idValue != null && vSize > idx && !duplicatePrimary.add(idValue)) {
-                        continue;
+                    if (idx < vSize) {
+                        Object idValue = values.get(idx);
+                        if (idValue != null && !duplicatePrimary.add(idValue)) {
+                            continue;
+                        }
                     }
                 }
                 // 唯一索引?
                 else if (indexSize >= 1) {
                     Set<Object> dis = Sets.newHashSetWithExpectedSize(indexSize);
                     for (Integer i : primaryIndex) {
-                        Object value = values.get(i);
-                        if (vSize > i && value != null) {
-                            dis.add(value);
+                        if (i < vSize) {
+                            Object value = values.get(i);
+                            if (value != null) {
+                                dis.add(value);
+                            }
                         }
                     }
                     // 存在重复数据 ?

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayParameter.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayParameter.java
@@ -1,0 +1,65 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import io.r2dbc.spi.Parameters;
+import io.r2dbc.spi.Statement;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hswebframework.ezorm.rdb.executor.JdbcParameterBinder;
+import org.hswebframework.ezorm.rdb.executor.R2dbcParameterBinder;
+
+import java.lang.reflect.Array;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.StringJoiner;
+
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+class PostgresqlArrayParameter implements JdbcParameterBinder, R2dbcParameterBinder {
+
+    private final PostgresqlArrayType type;
+
+    private final Object value;
+
+    @Override
+    public void bind(PreparedStatement statement, int index) throws SQLException {
+        if (value == null) {
+            statement.setNull(index, Types.ARRAY);
+            return;
+        }
+        statement.setArray(index, statement.getConnection().createArrayOf(type.getJdbcElementType(), toObjectArray()));
+    }
+
+    @Override
+    public void bind(Statement statement, String identifier) {
+        if (value == null) {
+            statement.bind(identifier, Parameters.in(type.getR2dbcArrayType()));
+            return;
+        }
+        statement.bind(identifier, Parameters.in(type.getR2dbcArrayType(), value));
+    }
+
+    private Object[] toObjectArray() {
+        if (value instanceof Object[] values) {
+            return values;
+        }
+        int len = Array.getLength(value);
+        Object[] values = new Object[len];
+        for (int i = 0; i < len; i++) {
+            values[i] = Array.get(value, i);
+        }
+        return values;
+    }
+
+    @Override
+    public String toString() {
+        if (value == null) {
+            return "null::" + type.getId();
+        }
+        StringJoiner joiner = new StringJoiner(",", "{", "}::" + type.getId());
+        for (Object element : toObjectArray()) {
+            joiner.add(element == null ? "NULL" : String.valueOf(element));
+        }
+        return joiner.toString();
+    }
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayTermFragmentBuilder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayTermFragmentBuilder.java
@@ -1,0 +1,150 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.EmptySqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.PrepareSqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.SqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.term.AbstractTermFragmentBuilder;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.List;
+
+public class PostgresqlArrayTermFragmentBuilder extends AbstractTermFragmentBuilder {
+
+    public static final PostgresqlArrayTermFragmentBuilder in = new PostgresqlArrayTermFragmentBuilder(
+        TermType.in,
+        "数组包含任一值",
+        null,
+        false
+    );
+
+    public static final PostgresqlArrayTermFragmentBuilder notIn = new PostgresqlArrayTermFragmentBuilder(
+        TermType.nin,
+        "数组不包含任一值",
+        null,
+        true
+    );
+
+    public static final PostgresqlArrayTermFragmentBuilder contains = new PostgresqlArrayTermFragmentBuilder(
+        TermType.contains,
+        "数组包含",
+        Operator.contains,
+        false
+    );
+
+    public static final PostgresqlArrayTermFragmentBuilder notContains = new PostgresqlArrayTermFragmentBuilder(
+        TermType.ncontains,
+        "数组不包含",
+        Operator.contains,
+        true
+    );
+
+    public static final PostgresqlArrayTermFragmentBuilder contained = new PostgresqlArrayTermFragmentBuilder(
+        TermType.contained,
+        "数组被包含",
+        Operator.contained,
+        false
+    );
+
+    public static final PostgresqlArrayTermFragmentBuilder notContained = new PostgresqlArrayTermFragmentBuilder(
+        TermType.ncontained,
+        "数组不被包含",
+        Operator.contained,
+        true
+    );
+
+    public static final PostgresqlArrayTermFragmentBuilder overlap = new PostgresqlArrayTermFragmentBuilder(
+        TermType.overlap,
+        "数组相交",
+        Operator.overlap,
+        false
+    );
+
+    public static final PostgresqlArrayTermFragmentBuilder notOverlap = new PostgresqlArrayTermFragmentBuilder(
+        TermType.noverlap,
+        "数组不相交",
+        Operator.overlap,
+        true
+    );
+
+    private final Operator operator;
+
+    private final boolean not;
+
+    public PostgresqlArrayTermFragmentBuilder(String termType,
+                                              String name,
+                                              Operator operator,
+                                              boolean not) {
+        super(termType, name);
+        this.operator = operator;
+        this.not = not;
+    }
+
+    @Override
+    public SqlFragments createFragments(String columnFullName, RDBColumnMetadata column, Term term) {
+        Object value = term.getValue();
+        if (isEmptyValue(value)) {
+            return EmptySqlFragments.INSTANCE;
+        }
+        PrepareSqlFragments fragments = PrepareSqlFragments.of();
+        if (not) {
+            fragments.addSql("not", "(");
+        }
+        fragments.addSql(columnFullName, resolveOperator(term).sql);
+        appendPrepareOrNative(fragments, encodeValue(column, value));
+        if (not) {
+            fragments.addSql(")");
+        }
+        return fragments;
+    }
+
+    private Object encodeValue(RDBColumnMetadata column, Object value) {
+        if (value instanceof NativeSql) {
+            return value;
+        }
+        return column.encode(value);
+    }
+
+    private Operator resolveOperator(Term term) {
+        if (operator != null) {
+            return operator;
+        }
+        List<String> options = term.getOptions();
+        if (options.contains("all") || options.contains("contains")) {
+            return Operator.contains;
+        }
+        if (options.contains("contained")) {
+            return Operator.contained;
+        }
+        return Operator.overlap;
+    }
+
+    private boolean isEmptyValue(Object value) {
+        if (value == null) {
+            return true;
+        }
+        if (value instanceof Collection<?> collection) {
+            return collection.isEmpty();
+        }
+        if (value.getClass().isArray()) {
+            return Array.getLength(value) == 0;
+        }
+        return false;
+    }
+
+    private enum Operator {
+        contains("@>"),
+        contained("<@"),
+        overlap("&&");
+
+        private final String sql;
+
+        Operator(String sql) {
+            this.sql = sql;
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayType.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayType.java
@@ -1,9 +1,11 @@
 package org.hswebframework.ezorm.rdb.supports.postgres;
 
+import io.r2dbc.postgresql.codec.PostgresqlObjectId;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hswebframework.ezorm.core.ValueCodec;
+import org.hswebframework.ezorm.core.meta.ColumnMetadata;
 import org.hswebframework.ezorm.rdb.metadata.DataType;
 import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
 import org.hswebframework.ezorm.rdb.metadata.dialect.DataTypeBuilder;
@@ -22,17 +24,21 @@ import java.util.List;
 @RequiredArgsConstructor(staticName = "of")
 public class PostgresqlArrayType implements DataType, ValueCodec<Object, Object>, DataTypeBuilder {
 
-    public static final PostgresqlArrayType VARCHAR_ARRAY = PostgresqlArrayType.of("varchar[]", String.class, String[].class);
+    public static final PostgresqlArrayType VARCHAR_ARRAY = PostgresqlArrayType.of("varchar[]", "varchar", PostgresqlObjectId.VARCHAR_ARRAY, String.class, String[].class);
 
-    public static final PostgresqlArrayType TEXT_ARRAY = PostgresqlArrayType.of("text[]", String.class, String[].class);
+    public static final PostgresqlArrayType TEXT_ARRAY = PostgresqlArrayType.of("text[]", "text", PostgresqlObjectId.TEXT_ARRAY, String.class, String[].class);
 
-    public static final PostgresqlArrayType SMALLINT_ARRAY = PostgresqlArrayType.of("smallint[]", Short.class, Short[].class);
+    public static final PostgresqlArrayType SMALLINT_ARRAY = PostgresqlArrayType.of("smallint[]", "int2", PostgresqlObjectId.INT2_ARRAY, Short.class, Short[].class);
 
-    public static final PostgresqlArrayType INTEGER_ARRAY = PostgresqlArrayType.of("integer[]", Integer.class, Integer[].class);
+    public static final PostgresqlArrayType INTEGER_ARRAY = PostgresqlArrayType.of("integer[]", "int4", PostgresqlObjectId.INT4_ARRAY, Integer.class, Integer[].class);
 
-    public static final PostgresqlArrayType BIGINT_ARRAY = PostgresqlArrayType.of("bigint[]", Long.class, Long[].class);
+    public static final PostgresqlArrayType BIGINT_ARRAY = PostgresqlArrayType.of("bigint[]", "int8", PostgresqlObjectId.INT8_ARRAY, Long.class, Long[].class);
 
     private final String name;
+
+    private final String jdbcElementType;
+
+    private final PostgresqlObjectId r2dbcArrayType;
 
     private final Class<?> componentType;
 
@@ -51,6 +57,11 @@ public class PostgresqlArrayType implements DataType, ValueCodec<Object, Object>
     @Override
     public Object encode(Object value) {
         return convert(value);
+    }
+
+    @Override
+    public Object encode(Object value, ColumnMetadata column) {
+        return PostgresqlArrayParameter.of(this, convert(value));
     }
 
     @Override

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayType.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayType.java
@@ -1,0 +1,266 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.hswebframework.ezorm.core.ValueCodec;
+import org.hswebframework.ezorm.rdb.metadata.DataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.DataTypeBuilder;
+import org.postgresql.util.PGobject;
+
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.sql.JDBCType;
+import java.sql.SQLException;
+import java.sql.SQLType;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class PostgresqlArrayType implements DataType, ValueCodec<Object, Object>, DataTypeBuilder {
+
+    public static final PostgresqlArrayType VARCHAR_ARRAY = PostgresqlArrayType.of("varchar[]", String.class, String[].class);
+
+    public static final PostgresqlArrayType TEXT_ARRAY = PostgresqlArrayType.of("text[]", String.class, String[].class);
+
+    public static final PostgresqlArrayType SMALLINT_ARRAY = PostgresqlArrayType.of("smallint[]", Short.class, Short[].class);
+
+    public static final PostgresqlArrayType INTEGER_ARRAY = PostgresqlArrayType.of("integer[]", Integer.class, Integer[].class);
+
+    public static final PostgresqlArrayType BIGINT_ARRAY = PostgresqlArrayType.of("bigint[]", Long.class, Long[].class);
+
+    private final String name;
+
+    private final Class<?> componentType;
+
+    private final Class<?> javaType;
+
+    @Override
+    public String getId() {
+        return name;
+    }
+
+    @Override
+    public SQLType getSqlType() {
+        return JDBCType.ARRAY;
+    }
+
+    @Override
+    public Object encode(Object value) {
+        return convert(value);
+    }
+
+    @Override
+    public Object decode(Object data) {
+        return convert(data);
+    }
+
+    @Override
+    public String createColumnDataType(RDBColumnMetadata columnMetaData) {
+        return name;
+    }
+
+    private Object convert(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (javaType.isInstance(value)) {
+            return value;
+        }
+        if (value instanceof java.sql.Array sqlArray) {
+            return convertSqlArray(sqlArray);
+        }
+        if (value instanceof PGobject pgObject) {
+            return convert(pgObject.getValue());
+        }
+        if (value instanceof Collection<?> collection) {
+            return convertCollection(collection);
+        }
+        if (value.getClass().isArray()) {
+            return convertJavaArray(value);
+        }
+        if (value instanceof CharSequence sequence) {
+            return parseArrayLiteral(sequence.toString());
+        }
+        return newArray(convertElement(value));
+    }
+
+    private Object convertSqlArray(java.sql.Array sqlArray) {
+        try {
+            return convert(sqlArray.getArray());
+        } catch (SQLException e) {
+            throw new IllegalArgumentException("Failed to read PostgreSQL array value", e);
+        } finally {
+            try {
+                sqlArray.free();
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    private Object convertCollection(Collection<?> collection) {
+        Object result = Array.newInstance(componentType, collection.size());
+        int index = 0;
+        for (Object element : collection) {
+            Array.set(result, index++, convertElement(element));
+        }
+        return result;
+    }
+
+    private Object convertJavaArray(Object array) {
+        int length = Array.getLength(array);
+        Object result = Array.newInstance(componentType, length);
+        for (int i = 0; i < length; i++) {
+            Array.set(result, i, convertElement(Array.get(array, i)));
+        }
+        return result;
+    }
+
+    private Object parseArrayLiteral(String literal) {
+        String value = StringUtils.trimToEmpty(literal);
+        if (value.isEmpty()) {
+            return Array.newInstance(componentType, 0);
+        }
+        if ((value.startsWith("{") && value.endsWith("}"))
+            || (value.startsWith("[") && value.endsWith("]"))
+            || (value.startsWith("(") && value.endsWith(")"))) {
+            value = value.substring(1, value.length() - 1);
+        }
+        if (value.isEmpty()) {
+            return Array.newInstance(componentType, 0);
+        }
+        List<Token> tokens = split(value);
+        Object result = Array.newInstance(componentType, tokens.size());
+        for (int i = 0; i < tokens.size(); i++) {
+            Token token = tokens.get(i);
+            Array.set(result, i, convertElement(token.value, token.quoted));
+        }
+        return result;
+    }
+
+    private List<Token> split(String value) {
+        List<Token> tokens = new ArrayList<>();
+        StringBuilder builder = new StringBuilder();
+        boolean inQuotes = false;
+        boolean escaping = false;
+        boolean quoted = false;
+        int depth = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (escaping) {
+                builder.append(ch);
+                escaping = false;
+                continue;
+            }
+            if (inQuotes) {
+                if (ch == '\\') {
+                    escaping = true;
+                    continue;
+                }
+                if (ch == '"') {
+                    inQuotes = false;
+                    quoted = true;
+                    continue;
+                }
+                builder.append(ch);
+                continue;
+            }
+            if (ch == '"') {
+                inQuotes = true;
+                continue;
+            }
+            if (ch == '{') {
+                depth++;
+                builder.append(ch);
+                continue;
+            }
+            if (ch == '}') {
+                if (depth > 0) {
+                    depth--;
+                }
+                builder.append(ch);
+                continue;
+            }
+            if (ch == ',' && depth == 0) {
+                tokens.add(new Token(builder.toString(), quoted));
+                builder.setLength(0);
+                quoted = false;
+                continue;
+            }
+            builder.append(ch);
+        }
+        tokens.add(new Token(builder.toString(), quoted));
+        return tokens;
+    }
+
+    private Object convertElement(Object element) {
+        return convertElement(element, false);
+    }
+
+    private Object convertElement(Object element, boolean quoted) {
+        if (element == null) {
+            return null;
+        }
+        if (componentType == String.class) {
+            String value = String.valueOf(element);
+            if (!quoted) {
+                value = value.trim();
+                if ("null".equalsIgnoreCase(value)) {
+                    return null;
+                }
+            }
+            return value;
+        }
+        if (componentType.isInstance(element)) {
+            return element;
+        }
+        if (element instanceof Number number) {
+            return fromNumber(number);
+        }
+        String value = quoted ? String.valueOf(element) : StringUtils.trimToNull(String.valueOf(element));
+        if (value == null) {
+            return null;
+        }
+        if (!quoted && "null".equalsIgnoreCase(value)) {
+            return null;
+        }
+        if (componentType == Short.class) {
+            return new BigDecimal(value).shortValue();
+        }
+        if (componentType == Integer.class) {
+            return new BigDecimal(value).intValue();
+        }
+        if (componentType == Long.class) {
+            return new BigDecimal(value).longValue();
+        }
+        return value;
+    }
+
+    private Object fromNumber(Number number) {
+        if (componentType == Short.class) {
+            return number.shortValue();
+        }
+        if (componentType == Integer.class) {
+            return number.intValue();
+        }
+        if (componentType == Long.class) {
+            return number.longValue();
+        }
+        return String.valueOf(number);
+    }
+
+    private Object newArray(Object value) {
+        Object result = Array.newInstance(componentType, 1);
+        Array.set(result, 0, value);
+        return result;
+    }
+
+    @RequiredArgsConstructor
+    private static class Token {
+        private final String value;
+        private final boolean quoted;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlDialect.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlDialect.java
@@ -51,6 +51,20 @@ public class PostgresqlDialect extends DefaultDialect {
         registerDataType("halfvec", VectorType.HALF_VECTOR);
         registerDataType("sparsevec", VectorType.SPARSE_VECTOR);
 
+        registerDataType("varchar[]", PostgresqlArrayType.VARCHAR_ARRAY);
+        registerDataType("text[]", PostgresqlArrayType.TEXT_ARRAY);
+        registerDataType("smallint[]", PostgresqlArrayType.SMALLINT_ARRAY);
+        registerDataType("integer[]", PostgresqlArrayType.INTEGER_ARRAY);
+        registerDataType("bigint[]", PostgresqlArrayType.BIGINT_ARRAY);
+        registerDataType("int2[]", PostgresqlArrayType.SMALLINT_ARRAY);
+        registerDataType("int4[]", PostgresqlArrayType.INTEGER_ARRAY);
+        registerDataType("int8[]", PostgresqlArrayType.BIGINT_ARRAY);
+        registerDataType("_varchar", PostgresqlArrayType.VARCHAR_ARRAY);
+        registerDataType("_text", PostgresqlArrayType.TEXT_ARRAY);
+        registerDataType("_int2", PostgresqlArrayType.SMALLINT_ARRAY);
+        registerDataType("_int4", PostgresqlArrayType.INTEGER_ARRAY);
+        registerDataType("_int8", PostgresqlArrayType.BIGINT_ARRAY);
+        registerDataType("character varying[]", PostgresqlArrayType.VARCHAR_ARRAY);
 
         registerDataType("json", JsonType.INSTANCE);
         registerDataType("jsonb", JsonbType.INSTANCE);

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlSchemaMetadata.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlSchemaMetadata.java
@@ -8,6 +8,7 @@ import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
 import org.hswebframework.ezorm.rdb.metadata.ValueCodecFactory;
 import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
 import org.hswebframework.ezorm.rdb.operator.CompositeExceptionTranslation;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NotFillOrNullFragmentBuilder;
 import org.hswebframework.ezorm.rdb.utils.FeatureUtils;
 
 import java.util.Optional;
@@ -58,6 +59,16 @@ public class PostgresqlSchemaMetadata extends RDBSchemaMetadata {
             if(column.getValueCodec() instanceof EnumValueCodec &&((EnumValueCodec) column.getValueCodec()).isToMask()){
                 column.addFeature(PostgresqlEnumInFragmentBuilder.in);
                 column.addFeature(PostgresqlEnumInFragmentBuilder.notIn);
+            }
+            if (column.getType() instanceof PostgresqlArrayType) {
+                column.addFeature(PostgresqlArrayTermFragmentBuilder.in);
+                column.addFeature(new NotFillOrNullFragmentBuilder(PostgresqlArrayTermFragmentBuilder.notIn));
+                column.addFeature(PostgresqlArrayTermFragmentBuilder.contains);
+                column.addFeature(new NotFillOrNullFragmentBuilder(PostgresqlArrayTermFragmentBuilder.notContains));
+                column.addFeature(PostgresqlArrayTermFragmentBuilder.contained);
+                column.addFeature(new NotFillOrNullFragmentBuilder(PostgresqlArrayTermFragmentBuilder.notContained));
+                column.addFeature(PostgresqlArrayTermFragmentBuilder.overlap);
+                column.addFeature(new NotFillOrNullFragmentBuilder(PostgresqlArrayTermFragmentBuilder.notOverlap));
             }
             if (column.getValueCodec() instanceof VectorType) {
                 column.addFeature(new PostgresqlVectorDistanceFunctionFragmentBuilder());

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/Containers.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/Containers.java
@@ -28,8 +28,8 @@ public class Containers {
                 .withEnv("POSTGRES_DB", "ezorm")
                 .withCommand("postgres", "-c", "max_connections=500")
                 .withExposedPorts(5432)
-                .waitingFor(Wait.forListeningPort());
-//                .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*",1));
+                .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*\n", 2)
+                                .withStartupTimeout(Duration.ofMinutes(2)));
     }
 
     @SneakyThrows

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/BasicCommonTests.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/BasicCommonTests.java
@@ -217,17 +217,21 @@ public abstract class BasicCommonTests {
 
         Assert.assertEquals(2, repository.save(e1, e2).getTotal());
 
-        getSqlExecutor()
-            .select("select * from entity_test_table where id in(?,?)",e1.getId(),e2.getId())
-            .forEach(System.out::println);
-
-        repository
+        List<BasicTestEntity> saved = repository
             .createQuery()
-            .select("id","tags")
+            .select("*")
             .where()
             .in("id", Arrays.asList(e1.getId(), e2.getId()))
-            .fetch()
-            .forEach(System.out::println);
+            .fetch();
+
+        Assert.assertEquals(2, saved.size());
+
+        java.util.Map<String, BasicTestEntity> entityMap = saved
+            .stream()
+            .collect(Collectors.toMap(BasicTestEntity::getId, entity -> entity));
+
+        Assert.assertEquals(e1.getTags(), entityMap.get(e1.getId()).getTags());
+        Assert.assertNull(entityMap.get(e2.getId()).getTags());
 
     }
 

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArraySupportTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArraySupportTest.java
@@ -1,0 +1,63 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.junit.Assert;
+import org.junit.Test;
+import org.postgresql.util.PGobject;
+
+import java.util.List;
+
+public class PostgresqlArraySupportTest {
+
+    @Test
+    public void testStringArrayCodec() throws Exception {
+        Assert.assertArrayEquals(new String[]{"a", "b"}, (String[]) PostgresqlArrayType.VARCHAR_ARRAY.encode(List.of("a", "b")));
+        Assert.assertArrayEquals(new String[]{"a", "b"}, (String[]) PostgresqlArrayType.VARCHAR_ARRAY.encode(new String[]{"a", "b"}));
+        Assert.assertArrayEquals(new String[]{"a", "b"}, (String[]) PostgresqlArrayType.VARCHAR_ARRAY.decode("{a,b}"));
+        Assert.assertArrayEquals(new String[]{"white shirt", "glasses", null}, (String[]) PostgresqlArrayType.TEXT_ARRAY.decode("{\"white shirt\",glasses,NULL}"));
+        Assert.assertArrayEquals(new String[]{"NULL", "a,b"}, (String[]) PostgresqlArrayType.TEXT_ARRAY.decode("{\"NULL\",\"a,b\"}"));
+
+        PGobject pgObject = new PGobject();
+        pgObject.setType("text[]");
+        pgObject.setValue("{\"white shirt\",glasses}");
+        Assert.assertArrayEquals(new String[]{"white shirt", "glasses"}, (String[]) PostgresqlArrayType.TEXT_ARRAY.decode(pgObject));
+    }
+
+    @Test
+    public void testNumberArrayCodec() {
+        Assert.assertArrayEquals(new Short[]{1, 2, 3}, (Short[]) PostgresqlArrayType.SMALLINT_ARRAY.encode(new short[]{1, 2, 3}));
+        Assert.assertArrayEquals(new Short[]{1, 2, 3}, (Short[]) PostgresqlArrayType.SMALLINT_ARRAY.decode("{1,2,3}"));
+        Assert.assertArrayEquals(new Integer[]{1, 2, 3}, (Integer[]) PostgresqlArrayType.INTEGER_ARRAY.encode(List.of(1L, 2L, 3L)));
+        Assert.assertArrayEquals(new Integer[]{1, 2, 3}, (Integer[]) PostgresqlArrayType.INTEGER_ARRAY.decode("{1,2,3}"));
+        Assert.assertArrayEquals(new Long[]{1L, 2L, 3L}, (Long[]) PostgresqlArrayType.BIGINT_ARRAY.encode(new int[]{1, 2, 3}));
+        Assert.assertArrayEquals(new Long[]{1L, null, 3L}, (Long[]) PostgresqlArrayType.BIGINT_ARRAY.decode("{1,NULL,3}"));
+    }
+
+    @Test
+    public void testArrayColumnType() {
+        RDBSchemaMetadata schema = createSchema();
+        RDBTableMetadata table = schema.newTable("test_array");
+        schema.addTable(table);
+
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("tags");
+        column.setOwner(table);
+        column.setType(table.getDialect().convertDataType("smallint[]"));
+        table.addColumn(column);
+
+        Assert.assertEquals("smallint[]", column.getDataType());
+        Assert.assertEquals(Short[].class, column.getJavaType());
+    }
+
+    private RDBSchemaMetadata createSchema() {
+        RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.POSTGRES);
+        RDBSchemaMetadata schema = new PostgresqlSchemaMetadata("public");
+        database.addSchema(schema);
+        database.setCurrentSchema(schema);
+        return schema;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlConnectionProvider.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlConnectionProvider.java
@@ -6,7 +6,6 @@ import org.hswebframework.ezorm.rdb.Containers;
 import org.junit.Assert;
 import org.postgresql.Driver;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -18,8 +17,6 @@ public class PostgresqlConnectionProvider implements ConnectionProvider {
     static {
         Assert.assertTrue(Driver.isRegistered());
         GenericContainer<?> container = Containers.newPostgresql("11");
-
-        container.waitingFor(Wait.forListeningPort());
         container.start();
         port = container.getMappedPort(5432);
     }

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlTableMetaParserTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlTableMetaParserTest.java
@@ -58,7 +58,12 @@ public class PostgresqlTableMetaParserTest {
                                                 "name varchar(128) not null," +
                                                 "age int4," +
                                                 "json1 json," +
-                                                "json2 jsonb" +
+                                                "json2 jsonb," +
+                                                "tags varchar[]," +
+                                                "keywords text[]," +
+                                                "codes smallint[]," +
+                                                "nums int4[]," +
+                                                "ids int8[]" +
                                                 ")"));
         try {
             RDBTableMetadata metaData = parser.parseByName("test_table").orElseThrow(NullPointerException::new);
@@ -119,6 +124,56 @@ public class PostgresqlTableMetaParserTest {
                 Assert.assertEquals(column.getType().getId(), "jsonb");
                 Assert.assertEquals(column.getSqlType(), JDBCType.CLOB);
                 Assert.assertEquals(column.getJavaType(), String.class);
+            }
+            //varchar[]
+            {
+                RDBColumnMetadata column = metaData.getColumn("tags").orElseThrow(NullPointerException::new);
+
+                Assert.assertNotNull(column);
+                Assert.assertEquals(column.getDataType(), "varchar[]");
+                Assert.assertEquals(column.getType().getId(), "varchar[]");
+                Assert.assertEquals(column.getSqlType(), JDBCType.ARRAY);
+                Assert.assertEquals(column.getJavaType(), String[].class);
+            }
+            //text[]
+            {
+                RDBColumnMetadata column = metaData.getColumn("keywords").orElseThrow(NullPointerException::new);
+
+                Assert.assertNotNull(column);
+                Assert.assertEquals(column.getDataType(), "text[]");
+                Assert.assertEquals(column.getType().getId(), "text[]");
+                Assert.assertEquals(column.getSqlType(), JDBCType.ARRAY);
+                Assert.assertEquals(column.getJavaType(), String[].class);
+            }
+            //smallint[]
+            {
+                RDBColumnMetadata column = metaData.getColumn("codes").orElseThrow(NullPointerException::new);
+
+                Assert.assertNotNull(column);
+                Assert.assertEquals(column.getDataType(), "smallint[]");
+                Assert.assertEquals(column.getType().getId(), "smallint[]");
+                Assert.assertEquals(column.getSqlType(), JDBCType.ARRAY);
+                Assert.assertEquals(column.getJavaType(), Short[].class);
+            }
+            //int4[]
+            {
+                RDBColumnMetadata column = metaData.getColumn("nums").orElseThrow(NullPointerException::new);
+
+                Assert.assertNotNull(column);
+                Assert.assertEquals(column.getDataType(), "integer[]");
+                Assert.assertEquals(column.getType().getId(), "integer[]");
+                Assert.assertEquals(column.getSqlType(), JDBCType.ARRAY);
+                Assert.assertEquals(column.getJavaType(), Integer[].class);
+            }
+            //int8[]
+            {
+                RDBColumnMetadata column = metaData.getColumn("ids").orElseThrow(NullPointerException::new);
+
+                Assert.assertNotNull(column);
+                Assert.assertEquals(column.getDataType(), "bigint[]");
+                Assert.assertEquals(column.getType().getId(), "bigint[]");
+                Assert.assertEquals(column.getSqlType(), JDBCType.ARRAY);
+                Assert.assertEquals(column.getJavaType(), Long[].class);
             }
         } finally {
             executor.execute(prepare("drop table test_table"));

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlTableMetaParserTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlTableMetaParserTest.java
@@ -112,7 +112,7 @@ public class PostgresqlTableMetaParserTest {
 
                 Assert.assertNotNull(column);
                 Assert.assertEquals(column.getDataType(), "json");
-                Assert.assertEquals(column.getSqlType(), JDBCType.CLOB);
+                Assert.assertEquals(column.getSqlType(), JDBCType.OTHER);
                 Assert.assertEquals(column.getJavaType(), String.class);
             }
             //jsonb
@@ -122,7 +122,7 @@ public class PostgresqlTableMetaParserTest {
                 Assert.assertNotNull(column);
                 Assert.assertEquals(column.getDataType(), "jsonb");
                 Assert.assertEquals(column.getType().getId(), "jsonb");
-                Assert.assertEquals(column.getSqlType(), JDBCType.CLOB);
+                Assert.assertEquals(column.getSqlType(), JDBCType.OTHER);
                 Assert.assertEquals(column.getJavaType(), String.class);
             }
             //varchar[]

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/array/PostgresqlArrayTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/array/PostgresqlArrayTest.java
@@ -19,6 +19,7 @@ import org.hswebframework.ezorm.rdb.mapping.SyncRepository;
 import org.hswebframework.ezorm.rdb.mapping.annotation.ColumnType;
 import org.hswebframework.ezorm.rdb.mapping.defaults.DefaultReactiveRepository;
 import org.hswebframework.ezorm.rdb.mapping.defaults.DefaultSyncRepository;
+import org.hswebframework.ezorm.rdb.mapping.defaults.SaveResult;
 import org.hswebframework.ezorm.rdb.mapping.jpa.JpaEntityTableMetadataParser;
 import org.hswebframework.ezorm.rdb.mapping.wrapper.EntityResultWrapper;
 import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
@@ -32,13 +33,17 @@ import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlSchemaMetadata;
 import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlConnectionProvider;
 import org.junit.Assert;
 import org.junit.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import javax.persistence.Column;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class PostgresqlArrayTest {
@@ -75,6 +80,83 @@ public class PostgresqlArrayTest {
                 .fetchOne()
                 .orElseThrow(NullPointerException::new);
             Assert.assertEquals("arr-sync", byKeywords.getId());
+        } finally {
+            try {
+                executor.execute(SqlRequests.of("drop table test_pg_array_basic"));
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    @Test
+    public void testSyncRepositoryCrud() {
+        RDBDatabaseMetadata database = getSyncDatabase();
+        DatabaseOperator operator = DefaultDatabaseOperator.of(database);
+        SyncSqlExecutor executor = getSyncSqlExecutor();
+        try {
+            SyncRepository<ArrayEntity, String> repository = createSyncRepository(database, operator);
+
+            SaveResult initial = repository.save(Arrays.asList(
+                entity("sync-save-1", new Short[]{1, 2}, new String[]{"person", "white shirt"}),
+                entity("sync-save-2", new Short[]{2, 3}, new String[]{"vehicle", "white car"})
+            ));
+            Assert.assertEquals(2, initial.getTotal());
+
+            SaveResult updated = repository.save(Arrays.asList(
+                entity("sync-save-1", new Short[]{7, 8}, new String[]{"person", "glasses"}),
+                entity("sync-save-3", new Short[]{3, 4}, new String[]{"event", "night"})
+            ));
+            Assert.assertEquals(2, updated.getTotal());
+
+            Assert.assertArrayEquals(
+                new Short[]{7, 8},
+                repository.findById("sync-save-1").orElseThrow(NullPointerException::new).getTags()
+            );
+
+            Assert.assertEquals(2, repository.insertBatch(Arrays.asList(
+                entity("sync-batch-1", new Short[]{8, 9}, new String[]{"batch", "one"}),
+                entity("sync-batch-2", new Short[]{9, 10}, new String[]{"batch", "two"})
+            )));
+
+            Assert.assertEquals(1, repository.updateById(
+                "sync-save-2",
+                entity("sync-save-2", new Short[]{5, 6}, new String[]{"vehicle", "updated"})
+            ));
+
+            Assert.assertArrayEquals(
+                new String[]{"vehicle", "updated"},
+                repository.findById("sync-save-2").orElseThrow(NullPointerException::new).getKeywords()
+            );
+
+            List<String> pagedIds = repository
+                .createQuery()
+                .where(ArrayEntity::getTags, new Short[]{8, 9})
+                .fetch()
+                .stream()
+                .map(ArrayEntity::getId)
+                .collect(Collectors.toList());
+            Assert.assertEquals(List.of("sync-batch-1"), pagedIds);
+
+            Assert.assertEquals(1, repository
+                .createUpdate()
+                .set(ArrayEntity::getKeywords, new String[]{"dsl", "updated"})
+                .where(ArrayEntity::getId, "sync-batch-2")
+                .execute());
+
+            Assert.assertArrayEquals(
+                new String[]{"dsl", "updated"},
+                repository.findById("sync-batch-2").orElseThrow(NullPointerException::new).getKeywords()
+            );
+
+            Assert.assertEquals(1, repository
+                .createDelete()
+                .where(ArrayEntity::getId, "sync-batch-1")
+                .execute());
+
+            Assert.assertTrue(repository.findById("sync-batch-1").isEmpty());
+            Assert.assertEquals(2, repository.deleteById(Arrays.asList("sync-save-1", "sync-save-3")));
+            Assert.assertEquals(1, repository.deleteById("sync-save-2"));
+            Assert.assertEquals(1, repository.deleteById("sync-batch-2"));
         } finally {
             try {
                 executor.execute(SqlRequests.of("drop table test_pg_array_basic"));
@@ -122,6 +204,119 @@ public class PostgresqlArrayTest {
             } catch (Exception ignore) {
             }
         }
+    }
+
+    @Test
+    public void testReactiveRepositoryCrud() {
+        RDBDatabaseMetadata database = getReactiveDatabase();
+        DatabaseOperator operator = DefaultDatabaseOperator.of(database);
+        ReactiveSqlExecutor executor = getReactiveSqlExecutor();
+        try {
+            ReactiveRepository<ArrayEntity, String> repository = createReactiveRepository(database, operator);
+
+            repository.save(Arrays.asList(
+                          entity("reactive-save-1", new Short[]{11, 12}, new String[]{"person", "hat"}),
+                          entity("reactive-save-2", new Short[]{12, 13}, new String[]{"vehicle", "black"})
+                      ))
+                      .as(StepVerifier::create)
+                      .assertNext(result -> Assert.assertEquals(2, result.getTotal()))
+                      .verifyComplete();
+
+            repository.save(Arrays.asList(
+                          entity("reactive-save-1", new Short[]{21, 22}, new String[]{"person", "updated"}),
+                          entity("reactive-save-3", new Short[]{13, 14}, new String[]{"event", "gate"})
+                      ))
+                      .as(StepVerifier::create)
+                      .assertNext(result -> Assert.assertEquals(2, result.getTotal()))
+                      .verifyComplete();
+
+            repository.findById("reactive-save-1")
+                      .as(StepVerifier::create)
+                      .assertNext(entity -> Assert.assertArrayEquals(new Short[]{21, 22}, entity.getTags()))
+                      .verifyComplete();
+
+            repository.insertBatch(Arrays.asList(
+                          entity("reactive-batch-1", new Short[]{31, 32}, new String[]{"batch", "reactive-1"}),
+                          entity("reactive-batch-2", new Short[]{32, 33}, new String[]{"batch", "reactive-2"})
+                      ))
+                      .as(StepVerifier::create)
+                      .expectNext(2)
+                      .verifyComplete();
+
+            repository.updateById("reactive-save-2",
+                                  Mono.just(entity("reactive-save-2",
+                                                   new Short[]{15, 16},
+                                                   new String[]{"vehicle", "updated"})))
+                      .as(StepVerifier::create)
+                      .expectNext(1)
+                      .verifyComplete();
+
+            repository.findById("reactive-save-2")
+                      .as(StepVerifier::create)
+                      .assertNext(entity -> Assert.assertArrayEquals(
+                          new String[]{"vehicle", "updated"},
+                          entity.getKeywords()))
+                      .verifyComplete();
+
+            repository
+                .createQuery()
+                .where(ArrayEntity::getTags, new Short[]{31, 32})
+                .fetch()
+                .map(ArrayEntity::getId)
+                .collectList()
+                .as(StepVerifier::create)
+                .assertNext(ids -> Assert.assertEquals(List.of("reactive-batch-1"), ids))
+                .verifyComplete();
+
+            repository.createUpdate()
+                      .set(ArrayEntity::getKeywords, new String[]{"dsl", "reactive"})
+                      .where(ArrayEntity::getId, "reactive-batch-2")
+                      .execute()
+                      .as(StepVerifier::create)
+                      .expectNext(1)
+                      .verifyComplete();
+
+            repository.findById("reactive-batch-2")
+                      .as(StepVerifier::create)
+                      .assertNext(entity -> Assert.assertArrayEquals(
+                          new String[]{"dsl", "reactive"},
+                          entity.getKeywords()))
+                      .verifyComplete();
+
+            repository.createDelete()
+                      .where(ArrayEntity::getId, "reactive-batch-1")
+                      .execute()
+                      .as(StepVerifier::create)
+                      .expectNext(1)
+                      .verifyComplete();
+
+            repository.findById("reactive-batch-1")
+                      .as(StepVerifier::create)
+                      .verifyComplete();
+
+            repository.deleteById(Flux.just("reactive-save-1", "reactive-save-3"))
+                      .as(StepVerifier::create)
+                      .expectNext(2)
+                      .verifyComplete();
+
+            repository.deleteById(Arrays.asList("reactive-save-2", "reactive-batch-2"))
+                      .as(StepVerifier::create)
+                      .expectNext(2)
+                      .verifyComplete();
+        } finally {
+            try {
+                executor.execute(Mono.just(SqlRequests.of("drop table test_pg_array_basic"))).block();
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    private ArrayEntity entity(String id, Short[] tags, String[] keywords) {
+        ArrayEntity entity = new ArrayEntity();
+        entity.setId(id);
+        entity.setTags(tags);
+        entity.setKeywords(keywords);
+        return entity;
     }
 
     private SyncRepository<ArrayEntity, String> createSyncRepository(RDBDatabaseMetadata database, DatabaseOperator operator) {

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/array/PostgresqlArrayTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/array/PostgresqlArrayTest.java
@@ -1,0 +1,218 @@
+package org.hswebframework.ezorm.rdb.supports.postgres.array;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.hswebframework.ezorm.core.DefaultValueGenerator;
+import org.hswebframework.ezorm.core.RuntimeDefaultValue;
+import org.hswebframework.ezorm.core.meta.ObjectMetadata;
+import org.hswebframework.ezorm.rdb.TestReactiveSqlExecutor;
+import org.hswebframework.ezorm.rdb.TestSyncSqlExecutor;
+import org.hswebframework.ezorm.rdb.executor.SqlRequests;
+import org.hswebframework.ezorm.rdb.executor.SyncSqlExecutor;
+import org.hswebframework.ezorm.rdb.executor.reactive.ReactiveSqlExecutor;
+import org.hswebframework.ezorm.rdb.executor.reactive.ReactiveSyncSqlExecutor;
+import org.hswebframework.ezorm.rdb.mapping.EntityColumnMapping;
+import org.hswebframework.ezorm.rdb.mapping.MappingFeatureType;
+import org.hswebframework.ezorm.rdb.mapping.ReactiveRepository;
+import org.hswebframework.ezorm.rdb.mapping.SyncRepository;
+import org.hswebframework.ezorm.rdb.mapping.annotation.ColumnType;
+import org.hswebframework.ezorm.rdb.mapping.defaults.DefaultReactiveRepository;
+import org.hswebframework.ezorm.rdb.mapping.defaults.DefaultSyncRepository;
+import org.hswebframework.ezorm.rdb.mapping.jpa.JpaEntityTableMetadataParser;
+import org.hswebframework.ezorm.rdb.mapping.wrapper.EntityResultWrapper;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.operator.DatabaseOperator;
+import org.hswebframework.ezorm.rdb.operator.DefaultDatabaseOperator;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlR2dbcConnectionProvider;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlSchemaMetadata;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlConnectionProvider;
+import org.junit.Assert;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import javax.persistence.Column;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@Slf4j
+public class PostgresqlArrayTest {
+
+    @Test
+    public void testSyncArrayField() {
+        RDBDatabaseMetadata database = getSyncDatabase();
+        DatabaseOperator operator = DefaultDatabaseOperator.of(database);
+        SyncSqlExecutor executor = getSyncSqlExecutor();
+        try {
+            SyncRepository<ArrayEntity, String> repository = createSyncRepository(database, operator);
+
+            ArrayEntity entity = new ArrayEntity();
+            entity.setId("arr-sync");
+            entity.setTags(new Short[]{1, 2, 3});
+            entity.setKeywords(new String[]{"person", "white shirt", "glasses"});
+
+            repository.insert(entity);
+
+            ArrayEntity loaded = repository.findById("arr-sync").orElseThrow(NullPointerException::new);
+            Assert.assertArrayEquals(new Short[]{1, 2, 3}, loaded.getTags());
+            Assert.assertArrayEquals(new String[]{"person", "white shirt", "glasses"}, loaded.getKeywords());
+
+            ArrayEntity byTags = repository
+                .createQuery()
+                .where(ArrayEntity::getTags, new Short[]{1, 2, 3})
+                .fetchOne()
+                .orElseThrow(NullPointerException::new);
+            Assert.assertEquals("arr-sync", byTags.getId());
+
+            ArrayEntity byKeywords = repository
+                .createQuery()
+                .where(ArrayEntity::getKeywords, new String[]{"person", "white shirt", "glasses"})
+                .fetchOne()
+                .orElseThrow(NullPointerException::new);
+            Assert.assertEquals("arr-sync", byKeywords.getId());
+        } finally {
+            try {
+                executor.execute(SqlRequests.of("drop table test_pg_array_basic"));
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    @Test
+    public void testReactiveArrayField() {
+        RDBDatabaseMetadata database = getReactiveDatabase();
+        DatabaseOperator operator = DefaultDatabaseOperator.of(database);
+        ReactiveSqlExecutor executor = getReactiveSqlExecutor();
+        try {
+            ReactiveRepository<ArrayEntity, String> repository = createReactiveRepository(database, operator);
+
+            ArrayEntity entity = new ArrayEntity();
+            entity.setId("arr-reactive");
+            entity.setTags(new Short[]{4, 5, 6});
+            entity.setKeywords(new String[]{"vehicle", "white", "plate"});
+
+            repository.insert(Mono.just(entity))
+                      .as(StepVerifier::create)
+                      .expectNext(1)
+                      .verifyComplete();
+
+            repository.findById(Mono.just("arr-reactive"))
+                      .as(StepVerifier::create)
+                      .assertNext(loaded -> {
+                          Assert.assertArrayEquals(new Short[]{4, 5, 6}, loaded.getTags());
+                          Assert.assertArrayEquals(new String[]{"vehicle", "white", "plate"}, loaded.getKeywords());
+                      })
+                      .verifyComplete();
+
+            repository
+                .createQuery()
+                .where(ArrayEntity::getTags, new Short[]{4, 5, 6})
+                .fetch()
+                .as(StepVerifier::create)
+                .assertNext(loaded -> Assert.assertEquals("arr-reactive", loaded.getId()))
+                .verifyComplete();
+        } finally {
+            try {
+                executor.execute(Mono.just(SqlRequests.of("drop table test_pg_array_basic"))).block();
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    private SyncRepository<ArrayEntity, String> createSyncRepository(RDBDatabaseMetadata database, DatabaseOperator operator) {
+        JpaEntityTableMetadataParser parser = new JpaEntityTableMetadataParser();
+        parser.setDatabaseMetadata(database);
+        RDBTableMetadata table = parser.parseTableMetadata(ArrayEntity.class).orElseThrow(NullPointerException::new);
+        operator.ddl().createOrAlter(table).commit().sync();
+
+        EntityResultWrapper<ArrayEntity> wrapper = new EntityResultWrapper<>(ArrayEntity::new);
+        wrapper.setMapping(table
+                               .<EntityColumnMapping>getFeature(MappingFeatureType.columnPropertyMapping.createFeatureId(ArrayEntity.class))
+                               .orElseThrow(NullPointerException::new));
+        return new DefaultSyncRepository<>(operator, table, ArrayEntity.class, wrapper);
+    }
+
+    private ReactiveRepository<ArrayEntity, String> createReactiveRepository(RDBDatabaseMetadata database, DatabaseOperator operator) {
+        JpaEntityTableMetadataParser parser = new JpaEntityTableMetadataParser();
+        parser.setDatabaseMetadata(database);
+        RDBTableMetadata table = parser.parseTableMetadata(ArrayEntity.class).orElseThrow(NullPointerException::new);
+        operator.ddl().createOrAlter(table).commit().reactive().block();
+
+        EntityResultWrapper<ArrayEntity> wrapper = new EntityResultWrapper<>(ArrayEntity::new);
+        wrapper.setMapping(table
+                               .<EntityColumnMapping>getFeature(MappingFeatureType.columnPropertyMapping.createFeatureId(ArrayEntity.class))
+                               .orElseThrow(NullPointerException::new));
+        return new DefaultReactiveRepository<>(operator, table, ArrayEntity.class, wrapper);
+    }
+
+    private RDBDatabaseMetadata getSyncDatabase() {
+        RDBDatabaseMetadata metadata = new RDBDatabaseMetadata(Dialect.POSTGRES);
+        RDBSchemaMetadata schema = getSchema();
+        metadata.setCurrentSchema(schema);
+        metadata.addSchema(schema);
+        metadata.addFeature(getSyncSqlExecutor());
+        return metadata;
+    }
+
+    private RDBDatabaseMetadata getReactiveDatabase() {
+        RDBDatabaseMetadata metadata = new RDBDatabaseMetadata(Dialect.POSTGRES);
+        RDBSchemaMetadata schema = getSchema();
+        metadata.setCurrentSchema(schema);
+        metadata.addSchema(schema);
+        ReactiveSqlExecutor executor = getReactiveSqlExecutor();
+        metadata.addFeature(executor);
+        metadata.addFeature(ReactiveSyncSqlExecutor.of(executor));
+        return metadata;
+    }
+
+    private RDBSchemaMetadata getSchema() {
+        PostgresqlSchemaMetadata schema = new PostgresqlSchemaMetadata("public");
+        schema.addFeature(new DefaultValueGenerator() {
+            @Override
+            public String getSortId() {
+                return "uuid";
+            }
+
+            @Override
+            public RuntimeDefaultValue generate(ObjectMetadata meta) {
+                return () -> UUID.randomUUID().toString().replace("-", "");
+            }
+
+            @Override
+            public String getName() {
+                return "UUID";
+            }
+        });
+        return schema;
+    }
+
+    private SyncSqlExecutor getSyncSqlExecutor() {
+        return new TestSyncSqlExecutor(new PostgresqlConnectionProvider());
+    }
+
+    private ReactiveSqlExecutor getReactiveSqlExecutor() {
+        return new TestReactiveSqlExecutor(new PostgresqlR2dbcConnectionProvider());
+    }
+
+    @Setter
+    @Getter
+    @Table(name = "test_pg_array_basic")
+    public static class ArrayEntity {
+        @Id
+        @Column(length = 32)
+        private String id;
+
+        @Column(nullable = false)
+        @ColumnType(typeId = "smallint[]")
+        private Short[] tags;
+
+        @Column(nullable = false)
+        @ColumnType(typeId = "text[]")
+        private String[] keywords;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/array/PostgresqlArrayTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/array/PostgresqlArrayTest.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hswebframework.ezorm.core.DefaultValueGenerator;
 import org.hswebframework.ezorm.core.RuntimeDefaultValue;
 import org.hswebframework.ezorm.core.meta.ObjectMetadata;
+import org.hswebframework.ezorm.core.param.TermType;
 import org.hswebframework.ezorm.rdb.TestReactiveSqlExecutor;
 import org.hswebframework.ezorm.rdb.TestSyncSqlExecutor;
 import org.hswebframework.ezorm.rdb.executor.SqlRequests;
@@ -166,6 +167,88 @@ public class PostgresqlArrayTest {
     }
 
     @Test
+    public void testSyncArrayTerms() {
+        RDBDatabaseMetadata database = getSyncDatabase();
+        DatabaseOperator operator = DefaultDatabaseOperator.of(database);
+        SyncSqlExecutor executor = getSyncSqlExecutor();
+        try {
+            SyncRepository<ArrayEntity, String> repository = createSyncRepository(database, operator);
+            repository.insertBatch(Arrays.asList(
+                entity("term-sync-1", new Short[]{1, 2, 3}, new String[]{"person", "white shirt", "glasses"}),
+                entity("term-sync-2", new Short[]{2, 4}, new String[]{"person", "black jacket"}),
+                entity("term-sync-3", new Short[]{5}, new String[]{"vehicle", "white"})
+            ));
+
+            assertIds(repository.createQuery()
+                                .contains(ArrayEntity::getTags, new Short[]{1, 2})
+                                .fetch()
+                                .stream()
+                                .map(ArrayEntity::getId)
+                                .collect(Collectors.toList()),
+                      "term-sync-1");
+
+            assertIds(repository.createQuery()
+                                .contained(ArrayEntity::getTags, new Short[]{1, 2, 3, 4})
+                                .fetch()
+                                .stream()
+                                .map(ArrayEntity::getId)
+                                .collect(Collectors.toList()),
+                      "term-sync-1",
+                      "term-sync-2");
+
+            assertIds(repository.createQuery()
+                                .overlap(ArrayEntity::getTags, new Short[]{2, 5})
+                                .fetch()
+                                .stream()
+                                .map(ArrayEntity::getId)
+                                .collect(Collectors.toList()),
+                      "term-sync-1",
+                      "term-sync-2",
+                      "term-sync-3");
+
+            assertIds(repository.createQuery()
+                                .notOverlap(ArrayEntity::getTags, new Short[]{5})
+                                .fetch()
+                                .stream()
+                                .map(ArrayEntity::getId)
+                                .collect(Collectors.toList()),
+                      "term-sync-1",
+                      "term-sync-2");
+
+            assertIds(repository.createQuery()
+                                .in(ArrayEntity::getTags, new Short[]{2, 5})
+                                .fetch()
+                                .stream()
+                                .map(ArrayEntity::getId)
+                                .collect(Collectors.toList()),
+                      "term-sync-1",
+                      "term-sync-2",
+                      "term-sync-3");
+
+            assertIds(repository.createQuery()
+                                .and("tags", TermType.in + "$all", new Short[]{1, 2})
+                                .fetch()
+                                .stream()
+                                .map(ArrayEntity::getId)
+                                .collect(Collectors.toList()),
+                      "term-sync-1");
+
+            assertIds(repository.createQuery()
+                                .contains(ArrayEntity::getKeywords, "white shirt")
+                                .fetch()
+                                .stream()
+                                .map(ArrayEntity::getId)
+                                .collect(Collectors.toList()),
+                      "term-sync-1");
+        } finally {
+            try {
+                executor.execute(SqlRequests.of("drop table test_pg_array_basic"));
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    @Test
     public void testReactiveArrayField() {
         RDBDatabaseMetadata database = getReactiveDatabase();
         DatabaseOperator operator = DefaultDatabaseOperator.of(database);
@@ -311,12 +394,87 @@ public class PostgresqlArrayTest {
         }
     }
 
+    @Test
+    public void testReactiveArrayTerms() {
+        RDBDatabaseMetadata database = getReactiveDatabase();
+        DatabaseOperator operator = DefaultDatabaseOperator.of(database);
+        ReactiveSqlExecutor executor = getReactiveSqlExecutor();
+        try {
+            ReactiveRepository<ArrayEntity, String> repository = createReactiveRepository(database, operator);
+
+            repository.insertBatch(Arrays.asList(
+                          entity("term-reactive-1", new Short[]{1, 2, 3}, new String[]{"person", "white shirt", "glasses"}),
+                          entity("term-reactive-2", new Short[]{2, 4}, new String[]{"person", "black jacket"}),
+                          entity("term-reactive-3", new Short[]{5}, new String[]{"vehicle", "white"})
+                      ))
+                      .as(StepVerifier::create)
+                      .expectNext(3)
+                      .verifyComplete();
+
+            repository.createQuery()
+                      .contains(ArrayEntity::getTags, new Short[]{1, 2})
+                      .fetch()
+                      .map(ArrayEntity::getId)
+                      .collectList()
+                      .as(StepVerifier::create)
+                      .assertNext(ids -> assertIds(ids, "term-reactive-1"))
+                      .verifyComplete();
+
+            repository.createQuery()
+                      .overlap(ArrayEntity::getTags, new Short[]{2, 5})
+                      .fetch()
+                      .map(ArrayEntity::getId)
+                      .collectList()
+                      .as(StepVerifier::create)
+                      .assertNext(ids -> assertIds(ids, "term-reactive-1", "term-reactive-2", "term-reactive-3"))
+                      .verifyComplete();
+
+            repository.createQuery()
+                      .and("tags", TermType.in + "$all", new Short[]{1, 2})
+                      .fetch()
+                      .map(ArrayEntity::getId)
+                      .collectList()
+                      .as(StepVerifier::create)
+                      .assertNext(ids -> assertIds(ids, "term-reactive-1"))
+                      .verifyComplete();
+
+            repository.createQuery()
+                      .in(ArrayEntity::getTags, new Short[]{2, 5})
+                      .fetch()
+                      .map(ArrayEntity::getId)
+                      .collectList()
+                      .as(StepVerifier::create)
+                      .assertNext(ids -> assertIds(ids, "term-reactive-1", "term-reactive-2", "term-reactive-3"))
+                      .verifyComplete();
+
+            repository.createQuery()
+                      .contains(ArrayEntity::getKeywords, "white shirt")
+                      .fetch()
+                      .map(ArrayEntity::getId)
+                      .collectList()
+                      .as(StepVerifier::create)
+                      .assertNext(ids -> assertIds(ids, "term-reactive-1"))
+                      .verifyComplete();
+        } finally {
+            try {
+                executor.execute(Mono.just(SqlRequests.of("drop table test_pg_array_basic"))).block();
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
     private ArrayEntity entity(String id, Short[] tags, String[] keywords) {
         ArrayEntity entity = new ArrayEntity();
         entity.setId(id);
         entity.setTags(tags);
         entity.setKeywords(keywords);
         return entity;
+    }
+
+    private void assertIds(List<String> ids, String... expected) {
+        List<String> actual = ids.stream().sorted().collect(Collectors.toList());
+        List<String> expect = Arrays.stream(expected).sorted().collect(Collectors.toList());
+        Assert.assertEquals(expect, actual);
     }
 
     private SyncRepository<ArrayEntity, String> createSyncRepository(RDBDatabaseMetadata database, DatabaseOperator operator) {

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
## 目的

- 为 easyorm PostgreSQL 方言增加一维数组类型的一等支持
- 避免业务模块继续通过 `columnDef("smallint[]")` 等方式绕过 ORM 类型系统
- 修复新版本 Docker Desktop / Testcontainers 环境下 PostgreSQL 集成测试无法执行的问题
- 补齐 PostgreSQL 数组场景下的完整 Repository 集成测试覆盖

## 核心变动

- 新增 `PostgresqlArrayType`，统一封装 PostgreSQL 数组类型的 `DataType`、`ValueCodec` 与 `DataTypeBuilder`
- 在 `PostgresqlDialect` 中注册 `varchar[]`、`text[]`、`smallint[]`、`integer[]`、`bigint[]` 及 PG 内部别名 `_varchar`、`_text`、`_int2`、`_int4`、`_int8`
- 新增 PostgreSQL 数组 typed binder：
  - `JdbcParameterBinder`
  - `R2dbcParameterBinder`
  - `PostgresqlArrayParameter`
- 修复 JDBC / R2DBC 下数组条件参数绑定，确保 `text[]`、`smallint[]` 等按正确 PostgreSQL 数组类型传参，避免 `text[] = character varying[]` 类型错误
- 升级 `org.testcontainers:testcontainers`：`1.17.1 -> 1.21.4`，兼容当前 Docker Desktop 环境
- 修正 PostgreSQL 元数据测试中 `json/jsonb` 的断言，使其与 PostgreSQL 方言 `JDBCType.OTHER` 语义一致
- 补充完整 Repository 集成测试，覆盖 sync/reactive 两套仓储 API 的 CRUD、save、批量插入、DSL update/delete、deleteById 等能力

## 测试结果

- 环境：macOS + Docker Desktop 4.63.0 + Docker Engine 29.2.1 + JDK 17
- 编译验证：
  - `mvn -pl hsweb-easy-orm-rdb -am -DskipTests compile`
  - `mvn -pl hsweb-easy-orm-rdb -am -DskipTests test-compile`
- PostgreSQL 数组相关测试：
  - `mvn -pl hsweb-easy-orm-rdb -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=PostgresqlArraySupportTest,PostgresqlTableMetaParserTest,org.hswebframework.ezorm.rdb.supports.postgres.array.PostgresqlArrayTest test`
  - 结果：Tests run **9**, Failures **0**, Errors **0**, Skipped **0**, **BUILD SUCCESS**
- 完整 Repository 集成测试：
  - `mvn -pl hsweb-easy-orm-rdb -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=org.hswebframework.ezorm.rdb.supports.postgres.array.PostgresqlArrayTest test`
  - 结果：Tests run **4**, Failures **0**, Errors **0**, Skipped **0**, **BUILD SUCCESS**

## 验证场景

- 数组 codec：`Collection` / Java 数组 / PG 字面量 / `PGobject`
- 表结构解析：
  - `varchar[]`
  - `text[]`
  - `smallint[]`
  - `integer[]`
  - `bigint[]`
- Repository round-trip：
  - JDBC 插入 / 查询
  - R2DBC 插入 / 查询
- 数组等值过滤：
  - `smallint[]`
  - `text[]`
- 完整仓储能力：
  - `save`
  - `insertBatch`
  - `updateById`
  - `findById`
  - `createQuery`
  - `createUpdate`
  - `createDelete`
  - `deleteById`

## 文档同步情况

- 当前 PR 无需同步额外文档

## 风险与说明

- 本次对执行器层新增了很小的 typed parameter binder 扩展点，用于支持 PostgreSQL 数组等需要显式类型绑定的场景
- 该扩展点未侵入现有普通参数路径，默认行为保持不变


## 增量更新（2026-05-19）

- 新增通用数组相关 termType：`contains`、`ncontains`、`contained`、`ncontained`、`overlap`、`noverlap`
- 在 core DSL 中补充：`contains/notContains`、`contained/notContained`、`overlap/notOverlap`
- PostgreSQL 数组列条件映射：
  - `contains -> @>`
  - `contained -> <@`
  - `overlap -> &&`
  - 数组列 `in` 兼容为 overlap（任一命中）
  - 数组列 `in$all` 兼容为 contains（全部命中）
- 升级 `org.jacoco:jacoco-maven-plugin`：`0.8.8 -> 0.8.14`，兼容 JDK 21，消除 `Unsupported class file major version 65` instrumentation 警告

## 增量测试结果（2026-05-19）

- 环境：macOS + Docker Desktop 4.63.0 + Docker Engine 29.2.1 + JDK 21
- `sh mvnw -pl hsweb-easy-orm-core -Dtest=QueryTest test`
  - 结果：Tests run **2**, Failures **0**, Errors **0**, Skipped **0**, **BUILD SUCCESS**
- `sh mvnw -pl hsweb-easy-orm-rdb -am -Dtest=PostgresqlArrayTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 结果：Tests run **6**, Failures **0**, Errors **0**, Skipped **0**, **BUILD SUCCESS**
- JaCoCo 升级后，验证日志中不再出现 `Unsupported class file major version 65` 告警


## 增量修复（2026-05-19 / R2DBC 兼容）

- 修复 `PostgresqlArrayType` 对 JDBC `org.postgresql.util.PGobject` 的硬依赖
- 调整为按类名判断并通过反射读取 `getValue()`，避免纯 R2DBC / 无 JDBC driver 场景下触发 `ClassNotFoundException`
- 该修复对 `retrieval-pg` 这类仅使用 PostgreSQL R2DBC 驱动但复用 easyorm PostgreSQL 数组 term / codec 的模块是必需的

### 补充验证

- `sh mvnw -pl hsweb-easy-orm-rdb -am -Dtest=PostgresqlArrayTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 结果：Tests run **6**, Failures **0**, Errors **0**, Skipped **0**, **BUILD SUCCESS**
