### PR TITLE
fix(rdb): 修复 upsert 批量值场景 ignoreUpdate 与列去重异常

### DIFF
--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/insert/BatchInsertSqlBuilder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/insert/BatchInsertSqlBuilder.java
@@ -128,16 +128,23 @@ public class BatchInsertSqlBuilder implements InsertSqlBuilder {
                 // 唯一索引?
                 else if (indexSize >= 1) {
                     Set<Object> dis = Sets.newHashSetWithExpectedSize(indexSize);
+                    boolean allKeyPresent = true;
                     for (Integer i : primaryIndex) {
                         if (i < vSize) {
                             Object value = values.get(i);
                             if (value != null) {
                                 dis.add(value);
+                            } else {
+                                allKeyPresent = false;
+                                break;
                             }
+                        } else {
+                            allKeyPresent = false;
+                            break;
                         }
                     }
                     // 存在重复数据 ?
-                    if (!duplicatePrimary.add(dis)) {
+                    if (allKeyPresent && !duplicatePrimary.add(dis)) {
                         continue;
                     }
                 }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/operator/dml/upsert/DefaultUpsertOperator.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/operator/dml/upsert/DefaultUpsertOperator.java
@@ -21,6 +21,8 @@ public class DefaultUpsertOperator extends UpsertOperator {
 
     private boolean columnValueModel = false;
 
+    private final Set<String> ignoreUpdateColumns = new HashSet<>();
+
     public static DefaultUpsertOperator of(RDBTableMetadata table) {
         DefaultUpsertOperator operator = new DefaultUpsertOperator();
 
@@ -31,6 +33,10 @@ public class DefaultUpsertOperator extends UpsertOperator {
 
     @Override
     public UpsertOperator ignoreUpdate(String... columns) {
+        if (columns == null || columns.length == 0) {
+            return this;
+        }
+        ignoreUpdateColumns.addAll(Arrays.asList(columns));
         for (UpsertColumn column : parameter.getColumns()) {
             for (String col : columns) {
                 if (column.getColumn().equals(col)) {
@@ -44,7 +50,7 @@ public class DefaultUpsertOperator extends UpsertOperator {
     @Override
     public UpsertOperator columns(String... columns) {
         for (String column : columns) {
-            parameter.getColumns().add(UpsertColumn.of(column, false));
+            parameter.getColumns().add(UpsertColumn.of(column, ignoreUpdateColumns.contains(column)));
         }
         columnValueModel = true;
         return this;
@@ -102,7 +108,7 @@ public class DefaultUpsertOperator extends UpsertOperator {
         if (columnValueModel) {
             throw new UnsupportedOperationException("columns or values already set");
         }
-        parameter.getColumns().add(UpsertColumn.of(column, ignoreUpdate));
+        parameter.getColumns().add(UpsertColumn.of(column, ignoreUpdate || ignoreUpdateColumns.contains(column)));
         List<List<Object>> values = parameter.getValues();
         if (values.isEmpty()) {
             values.add(new ArrayList<>());

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/operator/dml/upsert/UpsertColumn.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/operator/dml/upsert/UpsertColumn.java
@@ -11,6 +11,7 @@ import org.hswebframework.ezorm.rdb.operator.dml.insert.InsertColumn;
 @EqualsAndHashCode(callSuper = true)
 public class UpsertColumn extends InsertColumn {
 
+    @EqualsAndHashCode.Exclude
     private boolean updateIgnore;
 
     public static UpsertColumn of(String column,boolean updateIgnore){

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/dml/upsert/DefaultSaveOrUpdateOperatorTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/dml/upsert/DefaultSaveOrUpdateOperatorTest.java
@@ -3,6 +3,7 @@ package org.hswebframework.ezorm.rdb.operator.dml.upsert;
 import org.hswebframework.ezorm.core.RuntimeDefaultValue;
 import org.hswebframework.ezorm.rdb.TestReactiveSqlExecutor;
 import org.hswebframework.ezorm.rdb.TestSyncSqlExecutor;
+import org.hswebframework.ezorm.rdb.executor.wrapper.ResultWrappers;
 import org.hswebframework.ezorm.rdb.mapping.defaults.SaveResult;
 import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
 import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
@@ -17,6 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.test.StepVerifier;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
@@ -161,6 +165,183 @@ public class DefaultSaveOrUpdateOperatorTest {
                 .verifyComplete();
 
 
+    }
+
+    @Test
+    public void testSyncBatchValuesIgnoreUpdateBeforeValues() {
+        databaseOperator.ddl()
+                .createOrAlter("upsert_ignore_test")
+                .addColumn("id").primaryKey().varchar(32).commit()
+                .addColumn("name").varchar(32).commit()
+                .addColumn("age").integer().commit()
+                .commit()
+                .sync();
+
+        SaveResult result = databaseOperator
+                .dml()
+                .upsert("upsert_ignore_test")
+                .value("id", "123")
+                .value("name", "old")
+                .value("age", 1)
+                .execute()
+                .sync();
+
+        Assert.assertEquals(1, result.getAdded());
+
+        result = databaseOperator
+                .dml()
+                .upsert("upsert_ignore_test")
+                .ignoreUpdate("name")
+                .values(Arrays.asList(
+                        new LinkedHashMap<String, Object>() {{
+                            put("id", "123");
+                            put("name", "new");
+                            put("age", 2);
+                        }},
+                        new LinkedHashMap<String, Object>() {{
+                            put("id", "234");
+                            put("name", "created");
+                            put("age", 3);
+                        }}
+                ))
+                .execute()
+                .sync();
+
+        Assert.assertEquals(1, result.getUpdated());
+        Assert.assertEquals(1, result.getAdded());
+
+        Map<String, Object> updated = databaseOperator
+                .dml()
+                .query("upsert_ignore_test")
+                .select("id", "name", "age")
+                .where(dsl -> dsl.is("id", "123"))
+                .fetch(ResultWrappers.lowerCase(ResultWrappers.singleMap()))
+                .sync();
+
+        Assert.assertEquals("123", updated.get("id"));
+        Assert.assertEquals("old", updated.get("name"));
+        Assert.assertEquals(2, ((Number) updated.get("age")).intValue());
+
+        Map<String, Object> created = databaseOperator
+                .dml()
+                .query("upsert_ignore_test")
+                .select("id", "name", "age")
+                .where(dsl -> dsl.is("id", "234"))
+                .fetch(ResultWrappers.lowerCase(ResultWrappers.singleMap()))
+                .sync();
+
+        Assert.assertEquals("234", created.get("id"));
+        Assert.assertEquals("created", created.get("name"));
+        Assert.assertEquals(3, ((Number) created.get("age")).intValue());
+    }
+
+    @Test
+    public void testSyncIgnoreUpdateColumnMissingInAllValues() {
+        databaseOperator.ddl()
+                .createOrAlter("upsert_ignore_missing_all_test")
+                .addColumn("id").primaryKey().varchar(32).commit()
+                .addColumn("name").varchar(32).commit()
+                .addColumn("age").integer().commit()
+                .commit()
+                .sync();
+
+        SaveResult result = databaseOperator
+                .dml()
+                .upsert("upsert_ignore_missing_all_test")
+                .ignoreUpdate("name")
+                .values(Arrays.asList(
+                        new LinkedHashMap<String, Object>() {{
+                            put("id", "100");
+                            put("age", 10);
+                        }},
+                        new LinkedHashMap<String, Object>() {{
+                            put("id", "200");
+                            put("age", 20);
+                        }}
+                ))
+                .execute()
+                .sync();
+
+        Assert.assertEquals(2, result.getAdded());
+
+        Map<String, Object> data = databaseOperator
+                .dml()
+                .query("upsert_ignore_missing_all_test")
+                .select("id", "name", "age")
+                .where(dsl -> dsl.is("id", "100"))
+                .fetch(ResultWrappers.lowerCase(ResultWrappers.singleMap()))
+                .sync();
+
+        Assert.assertEquals("100", data.get("id"));
+        Assert.assertNull(data.get("name"));
+        Assert.assertEquals(10, ((Number) data.get("age")).intValue());
+    }
+
+    @Test
+    public void testSyncIgnoreUpdateColumnMissingInPartialValues() {
+        databaseOperator.ddl()
+                .createOrAlter("upsert_ignore_missing_partial_test")
+                .addColumn("id").primaryKey().varchar(32).commit()
+                .addColumn("name").varchar(32).commit()
+                .addColumn("age").integer().commit()
+                .commit()
+                .sync();
+
+        SaveResult result = databaseOperator
+                .dml()
+                .upsert("upsert_ignore_missing_partial_test")
+                .value("id", "100")
+                .value("name", "old")
+                .value("age", 1)
+                .execute()
+                .sync();
+
+        Assert.assertEquals(1, result.getAdded());
+
+        result = databaseOperator
+                .dml()
+                .upsert("upsert_ignore_missing_partial_test")
+                .ignoreUpdate("name")
+                .values(Arrays.asList(
+                        new LinkedHashMap<String, Object>() {{
+                            put("id", "100");
+                            put("age", 11);
+                        }},
+                        new LinkedHashMap<String, Object>() {{
+                            put("id", "200");
+                            put("name", "created");
+                            put("age", 22);
+                        }}
+                ))
+                .execute()
+                .sync();
+
+        Assert.assertEquals(1, result.getUpdated());
+        Assert.assertEquals(1, result.getAdded());
+
+        Map<String, Object> updated = databaseOperator
+                .dml()
+                .query("upsert_ignore_missing_partial_test")
+                .select("id", "name", "age")
+                .where(dsl -> dsl.is("id", "100"))
+                .fetch(ResultWrappers.lowerCase(ResultWrappers.singleMap()))
+                .sync();
+
+        Assert.assertEquals("100", updated.get("id"));
+        Assert.assertEquals("old", updated.get("name"));
+        Assert.assertEquals(11, ((Number) updated.get("age")).intValue());
+
+        Map<String, Object> created = databaseOperator
+                .dml()
+                .query("upsert_ignore_missing_partial_test")
+                .select("id", "name", "age")
+                .where(dsl -> dsl.is("id", "200"))
+                .fetch(ResultWrappers.lowerCase(ResultWrappers.singleMap()))
+                .sync();
+
+        Assert.assertEquals("200", created.get("id"));
+        Assert.assertEquals("created", created.get("name"));
+        Assert.assertEquals(22, ((Number) created.get("age")).intValue());
     }
 
 }

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/dml/upsert/DefaultUpsertOperatorTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/dml/upsert/DefaultUpsertOperatorTest.java
@@ -1,0 +1,104 @@
+package org.hswebframework.ezorm.rdb.operator.dml.upsert;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultUpsertOperatorTest {
+
+    @Test
+    public void testIgnoreUpdateAndBatchValuesWillNotDuplicateColumns() {
+        DefaultUpsertOperator operator = new DefaultUpsertOperator();
+
+        operator.columns("id", "name");
+        operator.ignoreUpdate("name");
+
+        List<Map<String, Object>> values = Arrays.asList(
+            new LinkedHashMap<String, Object>() {{
+                put("id", "1");
+                put("name", "n1");
+            }},
+            new LinkedHashMap<String, Object>() {{
+                put("id", "2");
+                put("name", "n2");
+            }}
+        );
+
+        operator.values(values);
+
+        Assert.assertEquals(2, operator.getParameter().getColumns().size());
+        Assert.assertArrayEquals(
+            new Object[]{"id", "name"},
+            operator.getParameter().getColumns().stream().map(UpsertColumn::getColumn).toArray()
+        );
+        Assert.assertTrue(
+            operator.getParameter()
+                    .getColumns()
+                    .stream()
+                    .filter(column -> "name".equals(column.getColumn()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new)
+                    .isUpdateIgnore()
+        );
+    }
+
+    @Test
+    public void testIgnoreUpdateBeforeBatchValuesShouldTakeEffect() {
+        DefaultUpsertOperator operator = new DefaultUpsertOperator();
+
+        operator.ignoreUpdate("id");
+        operator.values(Arrays.asList(
+            new LinkedHashMap<String, Object>() {{
+                put("id", "1");
+                put("name", "n1");
+            }},
+            new LinkedHashMap<String, Object>() {{
+                put("id", "2");
+                put("name", "n2");
+            }}
+        ));
+
+        Assert.assertEquals(2, operator.getParameter().getColumns().size());
+        Assert.assertTrue(
+            operator.getParameter()
+                    .getColumns()
+                    .stream()
+                    .filter(column -> "id".equals(column.getColumn()))
+                    .findFirst()
+                    .orElseThrow(AssertionError::new)
+                    .isUpdateIgnore()
+        );
+    }
+
+    @Test
+    public void testIgnoreUpdateColumnNotPresentInAnyValueShouldNotCreateColumn() {
+        DefaultUpsertOperator operator = new DefaultUpsertOperator();
+
+        operator.ignoreUpdate("name");
+        operator.values(Arrays.asList(
+            new LinkedHashMap<String, Object>() {{
+                put("id", "1");
+                put("age", 10);
+            }},
+            new LinkedHashMap<String, Object>() {{
+                put("id", "2");
+                put("age", 20);
+            }}
+        ));
+
+        Assert.assertArrayEquals(
+            new Object[]{"id", "age"},
+            operator.getParameter().getColumns().stream().map(UpsertColumn::getColumn).toArray()
+        );
+        Assert.assertFalse(
+            operator.getParameter()
+                    .getColumns()
+                    .stream()
+                    .anyMatch(column -> "name".equals(column.getColumn()))
+        );
+    }
+}


### PR DESCRIPTION
## 目的

- 修复 upsert 在批量 `values(List<Map<String,Object>>)` 场景下 `ignoreUpdate` 提前声明不生效的问题
- 修复 `ignoreUpdate` 与批量补列组合时可能出现的列重复问题
- 修复缺失主键/唯一键值时批量插入去重逻辑的边界异常，避免影响相关 upsert 路径

## 核心变动

- `DefaultUpsertOperator`
  - 缓存 `ignoreUpdate` 指定列
  - 支持先 `ignoreUpdate(...)` 再 `values(List<Map<String,Object>>)`
- `UpsertColumn`
  - 排除 `updateIgnore` 对 `equals/hashCode` 的影响，避免 `LinkedHashSet` 去重异常
- `BatchInsertSqlBuilder`
  - 调整批量主键/唯一键去重逻辑，仅在键值完整时参与重复过滤
- 新增/补充 upsert 相关单元与 H2 集成测试
  - 覆盖批量 map 值、列缺失、部分缺失、ignoreUpdate 生效与列不重复等场景

## 测试结果

- 命令：`export JAVA_HOME=$(/usr/libexec/java_home -v 17) && export PATH="$JAVA_HOME/bin:$PATH" && mvn -pl hsweb-easy-orm-rdb -Dtest=DefaultUpsertOperatorTest,DefaultSaveOrUpdateOperatorTest,DefaultDatabaseOperatorTest,BuildParameterInsertOperatorTest test`
- 测试结果：14 passed, 0 failed, 0 skipped
- 覆盖率（本次测试命令生成的 jacoco 报告）：line 28.7%, branch 20.7%

## 文档同步情况

- 未同步文档
- 原因：本次为 ORM 内部行为修复与测试补充，未引入新的外部使用方式或配置项

## 风险与说明

- 影响范围：`hsweb-easy-orm-rdb` 中 upsert 批量 map 值路径与批量插入去重逻辑
- 已覆盖场景：
  - `ignoreUpdate` 先声明后批量赋值
  - ignore 列在全部/部分 map 中缺失
  - 列去重与批量 upsert/update/insert 回归
- 未覆盖场景：其他数据库方言下的端到端执行仍主要依赖现有测试集
