### PR TITLE
refactor(PostgreSQL): 提取驱动类型判断工具

### DIFF
--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/json/JdbcPostgresqlJsonStringReader.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/json/JdbcPostgresqlJsonStringReader.java
@@ -1,5 +1,6 @@
 package org.hswebframework.ezorm.rdb.supports.json;
 
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlDriverUtils;
 import org.postgresql.util.PGobject;
 
 /**
@@ -9,12 +10,14 @@ public class JdbcPostgresqlJsonStringReader implements JsonStringReader {
 
     @Override
     public boolean supports(Object data) {
-        return data instanceof PGobject;
+        return PostgresqlDriverUtils.isPgObject(data) && data instanceof PGobject;
     }
 
     @Override
     public String read(Object data) {
-        String value = ((PGobject) data).getValue();
-        return value == null ? null : String.valueOf(value);
+        if (PostgresqlDriverUtils.isPgObject(data) && data instanceof PGobject) {
+            return ((PGobject) data).getValue();
+        }
+        return null;
     }
 }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/json/R2dbcPostgresqlJsonStringReader.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/json/R2dbcPostgresqlJsonStringReader.java
@@ -1,6 +1,7 @@
 package org.hswebframework.ezorm.rdb.supports.json;
 
 import io.r2dbc.postgresql.codec.Json;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlDriverUtils;
 
 /**
  * Reads JSON values returned by PostgreSQL R2DBC.
@@ -9,11 +10,14 @@ public class R2dbcPostgresqlJsonStringReader implements JsonStringReader {
 
     @Override
     public boolean supports(Object data) {
-        return data instanceof Json;
+        return PostgresqlDriverUtils.isR2dbcJson(data) && data instanceof Json;
     }
 
     @Override
     public String read(Object data) {
-        return ((Json) data).asString();
+        if (PostgresqlDriverUtils.isR2dbcJson(data) && data instanceof Json) {
+            return ((Json) data).asString();
+        }
+        return null;
     }
 }

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayType.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayType.java
@@ -84,7 +84,7 @@ public class PostgresqlArrayType implements DataType, ValueCodec<Object, Object>
         if (value instanceof java.sql.Array sqlArray) {
             return convertSqlArray(sqlArray);
         }
-        if (value instanceof PGobject pgObject) {
+        if (PostgresqlDriverUtils.isPgObject(value) && value instanceof PGobject pgObject) {
             return convert(pgObject.getValue());
         }
         if (value instanceof Collection<?> collection) {

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlDriverUtils.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlDriverUtils.java
@@ -1,0 +1,29 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+public final class PostgresqlDriverUtils {
+
+    private static final String PG_OBJECT_CLASS = "org.postgresql.util.PGobject";
+
+    private static final String R2DBC_JSON_CLASS = "io.r2dbc.postgresql.codec.Json";
+
+    private static final String R2DBC_VECTOR_CLASS = "io.r2dbc.postgresql.codec.Vector";
+
+    private PostgresqlDriverUtils() {
+    }
+
+    public static boolean isPgObject(Object value) {
+        return isExactClass(value, PG_OBJECT_CLASS);
+    }
+
+    public static boolean isR2dbcJson(Object value) {
+        return isExactClass(value, R2DBC_JSON_CLASS);
+    }
+
+    public static boolean isR2dbcVector(Object value) {
+        return isExactClass(value, R2DBC_VECTOR_CLASS);
+    }
+
+    private static boolean isExactClass(Object value, String className) {
+        return value != null && className.equals(value.getClass().getName());
+    }
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/VectorType.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/VectorType.java
@@ -61,17 +61,14 @@ public class VectorType implements DataType, ValueCodec<Object, Object>, DataTyp
         return toFloat(data);
     }
 
-    private static final String PG_OBJECT_CLASS = "org.postgresql.util.PGobject";
-    private static final String R2DBC_PG_OBJECT_CLASS = "io.r2dbc.postgresql.codec.Vector";
-
     private Float[] toFloat(Object data) {
         if (data == null) {
             return null;
         }
-        if (R2DBC_PG_OBJECT_CLASS.equals(data.getClass().getName()) && data instanceof Vector vector) {
+        if (PostgresqlDriverUtils.isR2dbcVector(data) && data instanceof Vector vector) {
             return toFloatArray(vector.getVector());
         }
-        if (PG_OBJECT_CLASS.equals(data.getClass().getName()) && data instanceof PGobject vector) {
+        if (PostgresqlDriverUtils.isPgObject(data) && data instanceof PGobject vector) {
             return toFloatArray(vector.getValue());
         }
         return toFloatArray(data);

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonCodecSupportTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonCodecSupportTest.java
@@ -2,6 +2,7 @@ package org.hswebframework.ezorm.rdb.supports.json;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.postgresql.util.PGobject;
 
 public class JsonCodecSupportTest {
 
@@ -30,11 +31,31 @@ public class JsonCodecSupportTest {
         Assert.assertEquals("ok", JsonCodecSupport.readAsString(new SampleJson("ok")));
     }
 
+    @Test
+    public void testJdbcPostgresqlJsonReader() throws Exception {
+        PGobject pgObject = new PGobject();
+        pgObject.setType("jsonb");
+        pgObject.setValue("{\"id\":\"test\"}");
+
+        JsonStringReader reader = new JdbcPostgresqlJsonStringReader();
+        Assert.assertTrue(reader.supports(pgObject));
+        Assert.assertEquals("{\"id\":\"test\"}", reader.read(pgObject));
+        Assert.assertFalse(reader.supports(new SamplePgObject("{\"id\":\"test\"}")));
+        Assert.assertNull(reader.read(new SamplePgObject("{\"id\":\"test\"}")));
+    }
+
     private static class SampleJson {
         private final String value;
 
         private SampleJson(String value) {
             this.value = value;
+        }
+    }
+
+    private static class SamplePgObject extends PGobject {
+
+        private SamplePgObject(String value) throws Exception {
+            setValue(value);
         }
     }
 }


### PR DESCRIPTION
## 变更说明
- 新增 `PostgresqlDriverUtils`，集中维护 PostgreSQL JDBC/R2DBC 驱动返回值的精确类名判断。
- 调整 JDBC/R2DBC JSON reader、数组类型和向量类型复用公共判断逻辑。
- 补充 JDBC JSON reader 单测，覆盖 `PGobject` 与其子类的匹配差异。

## 测试
- 已执行：`git diff --check`
- 未执行 Java 单元测试：按本地仓库指令，Java 编译/测试由用户自行完成。
- 建议执行：`java21 && mvn -pl hsweb-easy-orm-rdb -Dtest=JsonCodecSupportTest,PostgresqlArraySupportTest,PostgresqlVectorSupportTest test`

## 其他
- 不涉及 i18n。
- 不涉及 TraceHolder 链路追踪。
- 不涉及 MBean 运维观测。