### PR TITLE
test(rdb): 提升核心场景分支覆盖率

### DIFF
--- a/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/CoreUtilityBehaviorTest.java
+++ b/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/CoreUtilityBehaviorTest.java
@@ -1,0 +1,227 @@
+package org.hswebframework.ezorm.core;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.hswebframework.ezorm.core.utils.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.*;
+
+public class CoreUtilityBehaviorTest {
+
+    @Test
+    public void testStringUtilsForSqlNameAndDynamicParams() {
+        Assert.assertTrue(StringUtils.isNullOrEmpty(null));
+        Assert.assertTrue(StringUtils.isNullOrEmpty(""));
+        Assert.assertTrue(StringUtils.isNullOrEmpty(Collections.emptyList()));
+        Assert.assertTrue(StringUtils.isNullOrEmpty(Collections.emptyMap()));
+        Assert.assertFalse(StringUtils.isNullOrEmpty("device"));
+        Assert.assertFalse(StringUtils.isNullOrEmpty(Collections.singletonList("id")));
+
+        Assert.assertEquals("a,b,c", StringUtils.join(",", Arrays.asList("a", "b", "c")));
+        Assert.assertEquals("device.name", StringUtils.concat("device", ".", "name"));
+        Assert.assertEquals("device", StringUtils.toLowerCaseFirstOne("Device"));
+        Assert.assertEquals("device", StringUtils.toLowerCaseFirstOne("device"));
+        Assert.assertArrayEquals(new String[]{"a", "b", "c"}, StringUtils.split("a.b.c", '.'));
+        Assert.assertArrayEquals(new String[]{"a", "b"}, StringUtils.split("a.b.", '.'));
+        Assert.assertEquals("table", StringUtils.getPlainName("`table`"));
+        Assert.assertEquals("table", StringUtils.getPlainName("\"table\""));
+        Assert.assertEquals("table", StringUtils.getPlainName("[table]"));
+        Assert.assertArrayEquals(new String[]{"id", "name"}, StringUtils.getPlainName(new String[]{"`id`", "[name]"}));
+    }
+
+    @Test
+    public void testSimplePropertyWrapperConversions() {
+        Assert.assertEquals(12, new SimplePropertyWrapper(12L).toInt());
+        Assert.assertEquals(12, new SimplePropertyWrapper("12").toInt());
+        Assert.assertEquals(12.5D, new SimplePropertyWrapper("12.5").toDouble(), 0.0001D);
+        Assert.assertTrue(new SimplePropertyWrapper(true).isTrue());
+        Assert.assertTrue(new SimplePropertyWrapper(1).isTrue());
+        Assert.assertTrue(new SimplePropertyWrapper("yes").isTrue());
+        Assert.assertFalse(new SimplePropertyWrapper("no").isTrue());
+        Assert.assertTrue(new SimplePropertyWrapper(Collections.emptyList()).isNullOrEmpty());
+        Assert.assertFalse(new SimplePropertyWrapper(null).valueTypeOf(String.class));
+        Assert.assertTrue(new SimplePropertyWrapper("value").valueTypeOf(String.class));
+
+        Date now = new Date();
+        Assert.assertSame(now, new SimplePropertyWrapper(now).toDate());
+        Assert.assertEquals(now, new SimplePropertyWrapper(now).toDate("yyyy-MM-dd"));
+
+        Device device = new SimplePropertyWrapper("{\"id\":\"dev1\",\"count\":3}").toBean(Device.class);
+        Assert.assertEquals("dev1", device.getId());
+        Assert.assertEquals(3, device.getCount());
+        Assert.assertEquals("dev1", new SimplePropertyWrapper("{\"id\":\"dev1\"}").toMap().get("id"));
+        Assert.assertEquals("dev2", new SimplePropertyWrapper("[{\"id\":\"dev2\"}]").toBeanList(Device.class).get(0).getId());
+        Assert.assertEquals("dev3", ((Map<?, ?>) new SimplePropertyWrapper("[{\"id\":\"dev3\"}]").toList().get(0)).get("id"));
+
+        List<Device> devices = Collections.singletonList(device);
+        Assert.assertSame(devices, new SimplePropertyWrapper(devices).toBeanList(Device.class));
+        Assert.assertSame(device, new SimplePropertyWrapper(device).toBean(Device.class));
+    }
+
+    @Test
+    public void testObjectPropertyOperatorBeanAndExtensionBehavior() {
+        ApacheCommonPropertyOperator operator = ApacheCommonPropertyOperator.INSTANCE;
+        Device source = new Device();
+        source.setId("dev1");
+        source.setCount(7);
+
+        Assert.assertEquals("dev1", operator.getProperty(source, "id").orElse(null));
+        Assert.assertFalse(operator.getProperty(source, "missing").isPresent());
+        Assert.assertEquals(String.class, operator.getPropertyType(source, "id").orElse(null));
+        Assert.assertFalse(operator.getPropertyType(source, "missing").isPresent());
+
+        operator.setProperty(source, "count", "8");
+        Assert.assertEquals(8, source.getCount());
+
+        Device copied = operator.convert(source, Device.class);
+        Assert.assertEquals(source.getId(), copied.getId());
+        Assert.assertEquals(source.getCount(), copied.getCount());
+
+        Map<String, Object> map = operator.convert(source, LinkedHashMap::new);
+        Assert.assertEquals("dev1", map.get("id"));
+        Assert.assertEquals(8, map.get("count"));
+
+        ExtensionDevice ext = new ExtensionDevice();
+        operator.setProperty(ext, "dynamic", null);
+        Assert.assertTrue(ext.extensions().containsKey("dynamic"));
+        ext.withExtension(methodColumn("runtime", "online"));
+        ext.withExtension(staticColumn("id"), new Device());
+        ext.setExtension("intValue", 1);
+        ext.setExtension("longValue", 2L);
+        ext.setExtension("doubleValue", 3D);
+        ext.setExtension("floatValue", 4F);
+        ext.setExtension("booleanValue", true);
+        ext.setExtension("byteValue", (byte) 5);
+        ext.setExtension("charValue", 'c');
+        ext.setExtension("shortValue", (short) 6);
+        Assert.assertEquals("online", ext.getExtension("runtime"));
+        Assert.assertTrue(ext.getExtension("id") instanceof Device);
+
+        ExtensibleDevice oldExt = new ExtensibleDevice();
+        oldExt.setExtension(methodColumn("legacy", "ok"));
+        oldExt.setExtension(staticColumn("id"), new Device());
+        oldExt.setExtension("intValue", 1);
+        oldExt.setExtension("longValue", 2L);
+        oldExt.setExtension("doubleValue", 3D);
+        oldExt.setExtension("floatValue", 4F);
+        oldExt.setExtension("booleanValue", true);
+        oldExt.setExtension("byteValue", (byte) 5);
+        oldExt.setExtension("charValue", 'c');
+        oldExt.setExtension("shortValue", (short) 6);
+        Assert.assertEquals("ok", oldExt.getExtension("legacy"));
+        Assert.assertNull(new ExtensibleDevice(false).getExtension("missing"));
+    }
+
+    @Test
+    public void testObjectPropertyCompareAndAutoCreateNestedBean() {
+        ApacheCommonPropertyOperator operator = ApacheCommonPropertyOperator.INSTANCE;
+        Device device = new Device();
+
+        Assert.assertEquals(0, operator.compare("a", "a"));
+        Assert.assertTrue(operator.compare("a", "b") < 0);
+        Assert.assertTrue(operator.compare(1, 2L) < 0);
+        Assert.assertEquals(-1, operator.compare(new Object(), new Object()));
+
+        Object nested = operator.getPropertyOrNew(device, "nested");
+        Assert.assertTrue(nested instanceof Nested);
+        Assert.assertSame(nested, device.getNested());
+        Assert.assertNull(operator.getPropertyOrNew(device, "missing"));
+    }
+
+    private static <T> MethodReferenceColumn<T> methodColumn(String column, T value) {
+        return new TestMethodReferenceColumn<>(column, value);
+    }
+
+    private static <T> StaticMethodReferenceColumn<T> staticColumn(String column) {
+        return new TestStaticMethodReferenceColumn<>(column);
+    }
+
+    static class TestStaticMethodReferenceColumn<T> implements StaticMethodReferenceColumn<T> {
+        private final String column;
+
+        TestStaticMethodReferenceColumn(String column) {
+            this.column = column;
+        }
+
+        @Override
+        public String getColumn() {
+            return column;
+        }
+
+        @Override
+        public Object apply(T value) {
+            return null;
+        }
+    }
+
+    static class TestMethodReferenceColumn<T> implements MethodReferenceColumn<T> {
+        private final String column;
+        private final T value;
+
+        TestMethodReferenceColumn(String column, T value) {
+            this.column = column;
+            this.value = value;
+        }
+
+        @Override
+        public String getColumn() {
+            return column;
+        }
+
+        @Override
+        public T get() {
+            return value;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class Device implements Serializable {
+        private String id;
+        private int count;
+        private Nested nested;
+    }
+
+    public static class Nested implements Serializable {
+    }
+
+    public static class ExtensionDevice implements Extendable {
+        private final Map<String, Object> extensions = new LinkedHashMap<>();
+
+        @Override
+        public Map<String, Object> extensions() {
+            return extensions;
+        }
+
+        @Override
+        public void setExtension(String property, Object value) {
+            extensions.put(property, value);
+        }
+    }
+
+    @Deprecated
+    public static class ExtensibleDevice implements Extensible {
+        private final Map<String, Object> extensions;
+
+        public ExtensibleDevice() {
+            this(true);
+        }
+
+        public ExtensibleDevice(boolean createExtensions) {
+            this.extensions = createExtensions ? new LinkedHashMap<>() : null;
+        }
+
+        @Override
+        public Map<String, Object> extensions() {
+            return extensions;
+        }
+
+        @Override
+        public void setExtension(String property, Object value) {
+            extensions.put(property, value);
+        }
+    }
+}

--- a/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/NestConditionalLogicalOperationTest.java
+++ b/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/NestConditionalLogicalOperationTest.java
@@ -1,0 +1,294 @@
+package org.hswebframework.ezorm.core;
+
+import lombok.Getter;
+import org.hswebframework.ezorm.core.dsl.Query;
+import org.hswebframework.ezorm.core.param.QueryParam;
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NestConditionalLogicalOperationTest {
+
+    @Test
+    public void testNestConditionalCommonTerms() {
+        Query<Object, QueryParam> query = Query.of();
+
+        query.nest()
+             .and("name", "JetLinks")
+             .or("state", "enabled")
+             .like("like", "abc")
+             .like$("prefix", "abc")
+             .$like("suffix", "abc")
+             .$like$("contains", "abc")
+             .notLike("notLike", "abc")
+             .gt("gt", 1)
+             .lt("lt", 2)
+             .gte("gte", 3)
+             .lte("lte", 4)
+             .in("inArray", 1, 2)
+             .in("inValue", 1)
+             .in("inList", Arrays.asList(1, 2))
+             .notIn("notIn", Arrays.asList(3, 4))
+             .isEmpty("empty")
+             .notEmpty("notEmpty")
+             .isNull("isNull")
+             .notNull("notNull")
+             .not("not", 5)
+             .between("between", 1, 10)
+             .notBetween("notBetween", 2, 9)
+             .end();
+
+        Term nest = query.getParam().getTerms().get(0);
+        Assert.assertEquals(Term.Type.and, nest.getType());
+        Assert.assertEquals(22, nest.getTerms().size());
+        assertTerm(nest.getTerms().get(0), Term.Type.and, "name", TermType.eq, "JetLinks");
+        assertTerm(nest.getTerms().get(1), Term.Type.or, "state", TermType.eq, "enabled");
+        assertTerm(nest.getTerms().get(3), Term.Type.or, "prefix", TermType.like, "abc%");
+        assertTerm(nest.getTerms().get(4), Term.Type.or, "suffix", TermType.like, "%abc");
+        assertTerm(nest.getTerms().get(5), Term.Type.or, "contains", TermType.like, "%abc%");
+        Assert.assertEquals(Arrays.asList(1, 10), nest.getTerms().get(20).getValue());
+    }
+
+    @Test
+    public void testNestedNestAndNullLikeValues() {
+        Query<Object, QueryParam> query = Query.of();
+
+        NestConditional<Query<Object, QueryParam>> root = query.orNest();
+        root.like$("prefix", null)
+            .$like("suffix", null)
+            .$like$("contains", null)
+            .nest("child", "C")
+            .is("childName", "N")
+            .end()
+            .orNest("orChild", "O")
+            .is("orChildName", "ON")
+            .end()
+            .end();
+
+        Term rootTerm = query.getParam().getTerms().get(0);
+        Assert.assertEquals(Term.Type.or, rootTerm.getType());
+        Assert.assertNull(rootTerm.getColumn());
+        Assert.assertNull(rootTerm.getValue());
+        Assert.assertEquals(5, rootTerm.getTerms().size());
+        assertTerm(rootTerm.getTerms().get(0), Term.Type.and, "prefix", TermType.like, null);
+        assertTerm(rootTerm.getTerms().get(1), Term.Type.and, "suffix", TermType.like, null);
+        assertTerm(rootTerm.getTerms().get(2), Term.Type.and, "contains", TermType.like, null);
+        Assert.assertEquals(Term.Type.and, rootTerm.getTerms().get(3).getType());
+        Assert.assertEquals(Term.Type.or, rootTerm.getTerms().get(4).getType());
+    }
+
+    @Test
+    public void testLogicalOperationEachWhenAndAcceptHelpers() {
+        Query<Object, QueryParam> query = Query.of();
+        Map<String, Object> values = new LinkedHashMap<>();
+        values.put("name", "JetLinks");
+        values.put("age", 18);
+        AtomicInteger consumerCount = new AtomicInteger();
+
+        query.and((java.util.function.Supplier<Term>) () -> Term.of("supplierAnd", TermType.eq, "A"))
+             .or((java.util.function.Supplier<Term>) () -> Term.of("supplierOr", TermType.eq, "B"))
+             .each(Arrays.asList("A", "B"), (q, value) -> q.is("item", value))
+             .each("tag", Arrays.asList("x", "y"), q -> q::like)
+             .each("level", TermType.gt, Arrays.asList(1, 2), q -> q::and)
+             .each("mapped", Arrays.asList(1, 2), q -> q::is, value -> "v" + value)
+             .each(Entity::getName, Arrays.asList("J", "L"), Query::like, value -> value + "%")
+             .each(values, Query::is)
+             .when(true, q -> q.is("enabled", true))
+             .when(false, q -> q.is("ignored", true))
+             .when(() -> true, q -> q.is("supplied", true))
+             .when(true, "score", Query::gt, 90)
+             .when(false, "ignoredScore", Query::gt, 90)
+             .when(true, Entity::getAge, Query::gte, 18)
+             .when(true, Query::lt, methodColumn("age", 60))
+             .when("state", "enabled", value -> value.startsWith("enable"), q -> q::is)
+             .when("role", TermType.like, "admin", value -> value.startsWith("adm"), q -> q::and)
+             .when(Optional.of("optional"), (q, value) -> q.is("optional", value))
+             .when(Optional.empty(), (q, value) -> q.is("missingOptional", value))
+             .accept(q -> consumerCount.incrementAndGet())
+             .accept("accepted", (q, value) -> q.is("accepted", value))
+             ;
+
+        MethodReferenceColumn<String> method = NestConditionalLogicalOperationTest.<String>methodColumn("method", "value");
+        if (method.get() != null) {
+            query.is("method", method.get());
+        }
+        MethodReferenceColumn<String> nullMethod = NestConditionalLogicalOperationTest.<String>methodColumn("nullMethod", null);
+        if (nullMethod.get() != null) {
+            query.is("nullMethod", nullMethod.get());
+        }
+
+        Assert.assertSame(query, query.as(q -> q));
+        Assert.assertEquals(1, consumerCount.get());
+        Assert.assertEquals(24, query.getParam().getTerms().size());
+        Assert.assertFalse(query.getParam().getTerms().stream().anyMatch(term -> "ignored".equals(term.getColumn())));
+        Assert.assertFalse(query.getParam().getTerms().stream().anyMatch(term -> "missingOptional".equals(term.getColumn())));
+        Assert.assertFalse(query.getParam().getTerms().stream().anyMatch(term -> "nullMethod".equals(term.getColumn())));
+        Assert.assertEquals("v1", query.getParam().getTerms().get(8).getValue());
+    }
+
+    @Test
+    public void testNullCollectionsAndMapsAreIgnored() {
+        Query<Object, QueryParam> query = Query.of();
+
+        query.each((java.util.Collection<String>) null, (q, value) -> q.is("ignored", value))
+             .each("name", (java.util.Collection<String>) null, q -> q::like)
+             .each("name", TermType.eq, (java.util.Collection<String>) null, q -> q::and)
+             .each("name", (java.util.Collection<String>) null, q -> q::is, value -> value)
+             .each((Map<String, Object>) null, Query::is)
+             .each(Collections.emptyList(), value -> value, (q, value) -> q.is("ignored", value));
+
+        Assert.assertTrue(query.getParam().getTerms().isEmpty());
+    }
+
+
+    @Test
+    public void testNestConditionalMethodReferenceArrayJsonAndNullChecks() {
+        Query<Object, QueryParam> query = Query.of();
+        MethodReferenceColumn<String> name = methodColumn("name", "JetLinks");
+        MethodReferenceColumn<Integer> age = methodColumn("age", 18);
+        MethodReferenceColumn<Range> range = methodColumn("range", new Range(1, 9));
+
+        NestConditional<Query<Object, QueryParam>> nest = query.nest();
+        nest.is(staticColumn("product"), "gateway")
+            .is(name)
+            .like(staticColumn("name"), "Jet%")
+            .like(name)
+            .like$(name)
+            .$like(name)
+            .$like$(name)
+            .like$(staticColumn("prefix"), "pre")
+            .$like(staticColumn("suffix"), "suf")
+            .$like$(staticColumn("contains"), "mid")
+            .notLike(staticColumn("name"), "bad")
+            .notLike(name)
+            .gt(staticColumn("age"), 10)
+            .gt(age)
+            .lt(staticColumn("age"), 30)
+            .lt(age)
+            .gte(staticColumn("age"), 18)
+            .gte(age)
+            .lte(staticColumn("age"), 99)
+            .lte(age)
+            .in(staticColumn("state"), "enabled")
+            .in(staticColumn("state"), "enabled", "disabled")
+            .in(staticColumn("state"), Arrays.asList("enabled", "disabled"))
+            .in(methodColumn("state", "enabled"))
+            .notIn(staticColumn("state"), "removed")
+            .notIn(methodColumn("state", "removed"))
+            .contains(staticColumn("tags"), Collections.singleton("edge"))
+            .contains(methodColumn("tags", Collections.singleton("edge")))
+            .notContains(staticColumn("tags"), Collections.singleton("old"))
+            .notContains(methodColumn("tags", Collections.singleton("old")))
+            .contained(staticColumn("permissions"), Collections.singleton("read"))
+            .contained(methodColumn("permissions", Collections.singleton("read")))
+            .notContained(staticColumn("permissions"), Collections.singleton("root"))
+            .notContained(methodColumn("permissions", Collections.singleton("root")))
+            .overlap(staticColumn("areas"), Arrays.asList("A", "B"))
+            .overlap(methodColumn("areas", Collections.singleton("C")))
+            .notOverlap(staticColumn("areas"), Collections.singleton("Z"))
+            .notOverlap(methodColumn("areas", Collections.singleton("Y")))
+            .jsonExists("config", "$.enabled")
+            .jsonContains("config", Collections.singletonMap("enabled", true))
+            .jsonContained("config", Collections.singletonMap("version", 1))
+            .jsonValue("config", "$.version", TermType.gte, 2)
+            .jsonValue("config", "$.name", "JetLinks")
+            .isEmpty(staticColumn("description"))
+            .notEmpty(staticColumn("description"))
+            .isNull(staticColumn("deletedTime"))
+            .notNull(staticColumn("createdTime"))
+            .not(staticColumn("state"), "disabled")
+            .not(methodColumn("state", "disabled"))
+            .between(range, Range::getStart, Range::getEnd)
+            .between(staticColumn("age"), 1, 9)
+            .notBetween(staticColumn("age"), 10, 99)
+            .accept(staticColumn("custom"), "custom_term", "v")
+            .accept(methodColumn("methodCustom", "mv"), "method_term");
+        nest.and((java.util.function.Supplier<Term>) () -> Term.of("supplierAnd", TermType.eq, "A"));
+        nest.or((java.util.function.Supplier<Term>) () -> Term.of("supplierOr", TermType.eq, "B"));
+        nest.end();
+
+        Term root = query.getParam().getTerms().get(0);
+        Assert.assertEquals(56, root.getTerms().size());
+        Assert.assertEquals("json_value", root.getTerms().get(41).getTermType());
+        Assert.assertEquals(TermType.empty, root.getTerms().get(43).getTermType());
+        Assert.assertEquals(TermType.nbtw, root.getTerms().get(51).getTermType());
+        Assert.assertEquals("method_term", root.getTerms().get(53).getTermType());
+        Assert.assertEquals(Term.Type.and, root.getTerms().get(54).getType());
+        Assert.assertEquals(Term.Type.or, root.getTerms().get(55).getType());
+    }
+
+    private static <T> MethodReferenceColumn<T> methodColumn(String column, T value) {
+        return new TestMethodReferenceColumn<>(column, value);
+    }
+
+    private static <T> StaticMethodReferenceColumn<T> staticColumn(String column) {
+        return new TestStaticMethodReferenceColumn<>(column);
+    }
+
+    private static void assertTerm(Term term, Term.Type type, String column, String termType, Object value) {
+        Assert.assertEquals(type, term.getType());
+        Assert.assertEquals(column, term.getColumn());
+        Assert.assertEquals(termType, term.getTermType());
+        Assert.assertEquals(value, term.getValue());
+    }
+
+    static class TestStaticMethodReferenceColumn<T> implements StaticMethodReferenceColumn<T> {
+        private final String column;
+
+        TestStaticMethodReferenceColumn(String column) {
+            this.column = column;
+        }
+
+        @Override
+        public String getColumn() {
+            return column;
+        }
+
+        @Override
+        public Object apply(T value) {
+            return null;
+        }
+    }
+
+    @Getter
+    @lombok.AllArgsConstructor
+    static class Range implements Serializable {
+        private final int start;
+        private final int end;
+    }
+
+    static class TestMethodReferenceColumn<T> implements MethodReferenceColumn<T> {
+        private final String column;
+        private final T value;
+
+        TestMethodReferenceColumn(String column, T value) {
+            this.column = column;
+            this.value = value;
+        }
+
+        @Override
+        public String getColumn() {
+            return column;
+        }
+
+        @Override
+        public T get() {
+            return value;
+        }
+    }
+
+    @Getter
+    static class Entity implements Serializable {
+        private String name;
+        private Integer age;
+    }
+}

--- a/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/dsl/QueryDslBusinessTest.java
+++ b/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/dsl/QueryDslBusinessTest.java
@@ -1,0 +1,216 @@
+package org.hswebframework.ezorm.core.dsl;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hswebframework.ezorm.core.MethodReferenceColumn;
+import org.hswebframework.ezorm.core.StaticMethodReferenceColumn;
+import org.hswebframework.ezorm.core.param.Param;
+import org.hswebframework.ezorm.core.param.QueryParam;
+import org.hswebframework.ezorm.core.param.Sort;
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class QueryDslBusinessTest {
+
+    @Test
+    public void testQueryOptionsAndExecutionContract() {
+        Query<Object, QueryParam> query = Query.of();
+
+        Integer termCount = query.select("id", "name")
+                                 .selectExcludes("password")
+                                 .includes(methodColumn("runtime", "online"))
+                                 .excludes(methodColumn("secret", "x"))
+                                 .orderByAsc("name")
+                                 .orderByDesc("createTime")
+                                 .orderBy("score", sort -> sort.desc().function("abs").option("nulls", "last").value(0))
+                                 .doPaging(2, 20)
+                                 .noPaging()
+                                 .forUpdate()
+                                 .strictTerm(true)
+                                 .where("id", "dev1")
+                                 .execute(param -> param.getTerms().size());
+
+        QueryParam param = query.getParam();
+        Assert.assertEquals(Integer.valueOf(1), termCount);
+        Assert.assertTrue(param.getIncludes().contains("id"));
+        Assert.assertTrue(param.getIncludes().contains("runtime"));
+        Assert.assertTrue(param.getExcludes().contains("password"));
+        Assert.assertTrue(param.getExcludes().contains("secret"));
+        Assert.assertFalse(param.isPaging());
+        Assert.assertTrue(param.isForUpdate());
+        Assert.assertTrue(param.isStrictTerm());
+        Assert.assertEquals(Boolean.TRUE, param.getContext(QueryParam.STRICT_TERM_KEY).orElse(null));
+        Assert.assertEquals(3, param.getSorts().size());
+        Assert.assertEquals("asc", param.getSorts().get(0).getOrder());
+        Assert.assertEquals("desc", param.getSorts().get(1).getOrder());
+        Sort functionSort = param.getSorts().get(2);
+        Assert.assertEquals("abs", functionSort.getType());
+        Assert.assertEquals("last", functionSort.getOpts().get("nulls"));
+        Assert.assertEquals(0, functionSort.getValue());
+    }
+
+    @Test
+    public void testConditionalStringAndMethodReferenceTerms() {
+        Query<Object, QueryParam> query = Query.of();
+        MethodReferenceColumn<String> name = methodColumn("name", "JetLinks");
+        MethodReferenceColumn<Integer> age = methodColumn("age", 18);
+        MethodReferenceColumn<Range> range = methodColumn("range", new Range(10, 20));
+
+        query.where()
+             .where(q -> q.where("tenantId", "t1"))
+             .where(name)
+             .and(staticColumn("state"), TermType.eq, "enabled")
+             .or(staticColumn("type"), TermType.eq, "device")
+             .and(name)
+             .or(age)
+             .is(staticColumn("productId"), "prod1")
+             .is(name)
+             .like(name)
+             .like$(name)
+             .$like(name)
+             .$like$(name)
+             .notLike(name)
+             .gt(age)
+             .lt(age)
+             .gte(age)
+             .lte(age)
+             .in(age)
+             .notIn(age)
+             .between(range, Range::getStart, Range::getEnd)
+             .notBetween(range, Range::getStart, Range::getEnd)
+             .accept(staticColumn("custom"), "custom_term", "v")
+             .accept(methodColumn("methodCustom", "v2"), "custom_method");
+
+        Assert.assertEquals(23, query.getParam().getTerms().size());
+        Assert.assertEquals(Arrays.asList("tenantId", "name", "state", "type"), columns(query.getParam().getTerms()).subList(0, 4));
+        Assert.assertEquals(Term.Type.or, query.getParam().getTerms().get(3).getType());
+        Assert.assertEquals(TermType.like, query.getParam().getTerms().get(10).getTermType());
+        Assert.assertEquals("JetLinks%", query.getParam().getTerms().get(9).getValue());
+        Assert.assertEquals("%JetLinks", query.getParam().getTerms().get(10).getValue());
+        Assert.assertEquals("%JetLinks%", query.getParam().getTerms().get(11).getValue());
+        Assert.assertEquals(Arrays.asList(10, 20), query.getParam().getTerms().get(19).getValue());
+        Assert.assertEquals(TermType.nbtw, query.getParam().getTerms().get(20).getTermType());
+        Assert.assertEquals("custom_term", query.getParam().getTerms().get(21).getTermType());
+        Assert.assertEquals("custom_method", query.getParam().getTerms().get(22).getTermType());
+    }
+
+    @Test
+    public void testArrayAndJsonTermsForRepositoryQueries() {
+        Query<Object, QueryParam> query = Query.of();
+
+        query.contains(staticColumn("tags"), Collections.singleton("gateway"))
+             .contains(methodColumn("tags", Collections.singleton("edge")))
+             .notContains(staticColumn("tags"), Collections.singleton("deprecated"))
+             .notContains(methodColumn("tags", Collections.singleton("legacy")))
+             .contained(staticColumn("permissions"), Arrays.asList("read", "write"))
+             .contained(methodColumn("permissions", Collections.singleton("read")))
+             .notContained(staticColumn("permissions"), Collections.singleton("root"))
+             .notContained(methodColumn("permissions", Collections.singleton("guest")))
+             .overlap(staticColumn("areas"), Arrays.asList("A", "B"))
+             .overlap(methodColumn("areas", Collections.singleton("C")))
+             .notOverlap(staticColumn("areas"), Collections.singleton("Z"))
+             .notOverlap(methodColumn("areas", Collections.singleton("Y")))
+             .jsonExists("configuration", "$.network")
+             .jsonContains("configuration", Collections.singletonMap("enabled", true))
+             .jsonContained("configuration", Collections.singletonMap("version", 1))
+             .jsonValue("configuration", "$.version", TermType.gte, 2)
+             .jsonValue("configuration", "$.name", "JetLinks");
+
+        Assert.assertEquals(17, query.getParam().getTerms().size());
+        Assert.assertEquals(TermType.contains, query.getParam().getTerms().get(0).getTermType());
+        Assert.assertEquals(TermType.ncontains, query.getParam().getTerms().get(2).getTermType());
+        Assert.assertEquals(TermType.contained, query.getParam().getTerms().get(4).getTermType());
+        Assert.assertEquals(TermType.noverlap, query.getParam().getTerms().get(10).getTermType());
+        Assert.assertEquals("json_exists", query.getParam().getTerms().get(12).getTermType());
+        Map<?, ?> value = (Map<?, ?>) query.getParam().getTerms().get(15).getValue();
+        Assert.assertEquals("$.version", value.get("path"));
+        Assert.assertEquals(TermType.gte, value.get("termType"));
+        Assert.assertEquals(2, value.get("value"));
+        Assert.assertEquals(TermType.eq, ((Map<?, ?>) query.getParam().getTerms().get(16).getValue()).get("termType"));
+    }
+
+    @Test
+    public void testAcceptParamAndNullConditionsAreIgnoredByQuery() {
+        Param param = new Param();
+        param.and("id", TermType.eq, "dev1");
+        param.or("name", TermType.like, "%gateway%");
+
+        Query<Object, QueryParam> query = Query.of()
+                                               .where("ignored", TermType.eq, null)
+                                               .and("ignoredAnd", TermType.eq, null)
+                                               .or("ignoredOr", TermType.eq, null)
+                                               .like$("nullableLike", null)
+                                               .accept(param);
+
+        Assert.assertEquals(2, query.getParam().getTerms().size());
+        Assert.assertEquals("id", query.getParam().getTerms().get(0).getColumn());
+        Assert.assertEquals(Term.Type.or, query.getParam().getTerms().get(1).getType());
+    }
+
+    private static List<String> columns(List<Term> terms) {
+        return terms.stream().map(Term::getColumn).collect(Collectors.toList());
+    }
+
+    private static <T> MethodReferenceColumn<T> methodColumn(String column, T value) {
+        return new TestMethodReferenceColumn<>(column, value);
+    }
+
+    private static <T> StaticMethodReferenceColumn<T> staticColumn(String column) {
+        return new TestStaticMethodReferenceColumn<>(column);
+    }
+
+    static class TestMethodReferenceColumn<T> implements MethodReferenceColumn<T> {
+        private final String column;
+        private final T value;
+
+        TestMethodReferenceColumn(String column, T value) {
+            this.column = column;
+            this.value = value;
+        }
+
+        @Override
+        public String getColumn() {
+            return column;
+        }
+
+        @Override
+        public T get() {
+            return value;
+        }
+    }
+
+    static class TestStaticMethodReferenceColumn<T> implements StaticMethodReferenceColumn<T> {
+        private final String column;
+
+        TestStaticMethodReferenceColumn(String column) {
+            this.column = column;
+        }
+
+        @Override
+        public String getColumn() {
+            return column;
+        }
+
+        @Override
+        public Object apply(T value) {
+            return null;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class Range implements Serializable {
+        private final int start;
+        private final int end;
+    }
+}

--- a/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/dsl/UpdateDeleteTest.java
+++ b/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/dsl/UpdateDeleteTest.java
@@ -1,0 +1,96 @@
+package org.hswebframework.ezorm.core.dsl;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.hswebframework.ezorm.core.param.Param;
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.UpdateParam;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class UpdateDeleteTest {
+
+    @Test
+    public void testUpdateMapDsl() {
+        Update<Map<String, Object>, UpdateParam<Map<String, Object>>> update = Update.of();
+
+        update.set("name", "JetLinks")
+              .set(Map.of("state", 1))
+              .includes("name")
+              .excludes("ignore")
+              .where("id", "eq", "test")
+              .or("name", "like", "Jet")
+              .and("ignored", "eq", null);
+
+        Assert.assertEquals("JetLinks", update.getParam().getData().get("name"));
+        Assert.assertEquals(1, update.getParam().getData().get("state"));
+        Assert.assertTrue(update.getParam().getIncludes().contains("name"));
+        Assert.assertTrue(update.getParam().getExcludes().contains("ignore"));
+        Assert.assertEquals(2, update.getParam().getTerms().size());
+        Assert.assertEquals("test", update.execute(param -> param.getTerms().get(0).getValue()));
+    }
+
+    @Test
+    public void testUpdateBeanDslAndNest() {
+        Entity entity = new Entity();
+        Update<Entity, UpdateParam<Entity>> update = Update.of(entity);
+
+        update.set(Entity::getName, "JetLinks")
+              .includes(Entity::getName)
+              .excludes(Entity::getIgnored)
+              .nest()
+              .and("id", "eq", "1")
+              .orNest("name", "like")
+              .and("state", "eq", 1)
+              .end()
+              .end();
+
+        Assert.assertEquals("JetLinks", entity.getName());
+        Assert.assertTrue(update.getParam().getIncludes().contains("name"));
+        Assert.assertTrue(update.getParam().getExcludes().contains("ignored"));
+        Assert.assertEquals(1, update.getParam().getTerms().size());
+        Term root = update.getParam().getTerms().get(0);
+        Assert.assertEquals(2, root.getTerms().size());
+        Assert.assertEquals(Term.Type.or, root.getTerms().get(1).getType());
+    }
+
+    @Test
+    public void testDeleteDsl() {
+        Delete<Param> delete = Delete.of();
+
+        delete.where("id", "eq", "test")
+              .or("name", "like", "Jet")
+              .and("ignored", "eq", null)
+              .nest()
+              .and("state", "eq", 1)
+              .end();
+
+        Assert.assertEquals(3, delete.getParam().getTerms().size());
+        Assert.assertEquals("test", delete.execute(param -> param.getTerms().get(0).getValue()));
+
+        Param custom = new Param();
+        Delete<Param> supplied = Delete.of(() -> custom);
+        Assert.assertSame(custom, supplied.getParam());
+        Assert.assertSame(supplied, supplied.setParam(new Param()));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testUpdateRejectsNullData() {
+        Update.of((Map<String, Object>) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testUpdateRejectsNullParamData() {
+        Update.of(new UpdateParam<>(null));
+    }
+
+    @Getter
+    @Setter
+    public static class Entity {
+        private String id;
+        private String name;
+        private String ignored;
+    }
+}

--- a/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/meta/MetadataSupportTest.java
+++ b/hsweb-easy-orm-core/src/test/java/org/hswebframework/ezorm/core/meta/MetadataSupportTest.java
@@ -1,0 +1,359 @@
+package org.hswebframework.ezorm.core.meta;
+
+import org.hswebframework.ezorm.core.DictionaryCodec;
+import org.hswebframework.ezorm.core.FeatureId;
+import org.hswebframework.ezorm.core.FeatureType;
+import org.hswebframework.ezorm.core.ValueCodec;
+import org.junit.Assert;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class MetadataSupportTest {
+
+    @Test
+    public void testFeatureLookupAndFallback() {
+        TestDatabase database = new TestDatabase("db");
+        TestSchema schema = new TestSchema("schema");
+        database.addSchema(schema);
+        schema.setDatabase(database);
+
+        TestFeature schemaFeature = new TestFeature("schemaFeature", Type.metadata);
+        TestFeature databaseFeature = new TestFeature("databaseFeature", Type.metadata);
+        schema.addFeature(schemaFeature);
+        database.addFeature(databaseFeature);
+
+        Assert.assertEquals(1, schema.getFeatureList().size());
+        Assert.assertSame(schemaFeature, schema.getFeature(Type.metadata).orElse(null));
+        Assert.assertSame(schemaFeature, schema.getFeatures(Type.metadata).get(0));
+        Assert.assertSame(schemaFeature, schema.getFeatureNow(FeatureId.of("schemaFeature")));
+        Assert.assertSame(databaseFeature, schema.findFeatureNow("databaseFeature"));
+        Assert.assertTrue(schema.supportFeature("schemaFeature"));
+        Assert.assertTrue(schema.supportFeature(schemaFeature));
+        Assert.assertEquals("fallback", schema.findFeatureOrElse("missing", () -> new TestFeature("fallback", Type.other)).getId());
+
+        try {
+            schema.getFeatureNow("missing");
+            Assert.fail("missing feature should fail");
+        } catch (UnsupportedOperationException e) {
+            Assert.assertTrue(e.getMessage().contains("missing"));
+        }
+    }
+
+    @Test
+    public void testDatabaseSchemaAndObjectLookup() {
+        TestDatabase database = new TestDatabase("db");
+        TestSchema publicSchema = new TestSchema("public");
+        publicSchema.setAlias("pub");
+        database.setCurrentSchema(publicSchema);
+        database.addSchema(publicSchema);
+
+        TestObject table = new TestObject("device", "dev", Type.object);
+        publicSchema.addObject(table);
+
+        Assert.assertSame(publicSchema, database.getSchema("public").orElse(null));
+        Assert.assertSame(publicSchema, database.getSchema("pub").orElse(null));
+        Assert.assertEquals(2, database.getSchemas().size());
+        Assert.assertSame(table, database.getObject("device", (schema, name) -> schema.getObject(Type.object, name)).orElse(null));
+        Assert.assertSame(table, database.getObject("public.device", (schema, name) -> schema.getObject(Type.object, name)).orElse(null));
+        Assert.assertFalse(database.getObject(null, (schema, name) -> Optional.empty()).isPresent());
+
+        Assert.assertSame(table, database.getObjectReactive("public.device",
+                                                           (schema, name) -> schema.getObjectReactive(Type.object, name))
+                                         .block());
+        Assert.assertNull(database.getObjectReactive(null, (schema, name) -> Mono.empty()).block());
+
+        AbstractDatabaseMetadata<TestSchema> cloned = database.clone();
+        Assert.assertNotSame(database, cloned);
+        Assert.assertSame(database.getCurrentSchema(), cloned.getCurrentSchema());
+        Assert.assertNotSame(database.getSchema("public").orElse(null), cloned.getSchema("public").orElse(null));
+        Assert.assertSame(table, publicSchema.removeObject(Type.object, "device").orElse(null));
+        Assert.assertFalse(publicSchema.getObject(Type.object, "device").isPresent());
+    }
+
+
+
+    @Test
+    public void testSchemaParserAutoLoadAndCacheBehavior() {
+        TestSchema schema = new TestSchema("public");
+        ParserFeature parser = new ParserFeature();
+        ParserFeature otherParser = new OtherParserFeature();
+        schema.addFeature(parser);
+        schema.addFeature(otherParser);
+
+        Assert.assertEquals(2, schema.getObject(Type.object).size());
+        Assert.assertEquals(1, parser.parseAllCount);
+        Assert.assertEquals(2, schema.getObject(Type.object).size());
+        Assert.assertEquals("deviceA", schema.getObject(Type.object, "deviceA").orElseThrow().getName());
+        Assert.assertEquals("deviceB", schema.getObject(Type.object, "deviceB").orElseThrow().getName());
+        Assert.assertFalse(schema.getObject(Type.object, "unknown").isPresent());
+
+        Assert.assertFalse(schema.getObject(Type.other, "remote", false).isPresent());
+        Assert.assertEquals("remote", schema.getObject(Type.other, "`remote`", true).orElseThrow().getName());
+        Assert.assertEquals(1, otherParser.parseByNameCount);
+        Assert.assertEquals("remote", schema.getObject(Type.other, "remote", true).orElseThrow().getName());
+        Assert.assertEquals(1, otherParser.parseByNameCount);
+
+        Assert.assertEquals("reactive", schema.getObjectReactive(Type.other, "\"reactive\"", true).block().getName());
+        Assert.assertEquals(1, otherParser.parseByNameReactiveCount);
+        Assert.assertEquals("reactive", schema.getObjectReactive(Type.other, "reactive", false).block().getName());
+        Assert.assertEquals(1, otherParser.parseByNameReactiveCount);
+
+        schema.removeObject(Type.object, "deviceA");
+        Assert.assertFalse(schema.getObject(Type.object, "deviceA").isPresent());
+    }
+
+    @Test
+    public void testSchemaReactiveLoadAllAndCloneFeatures() {
+        TestSchema schema = new TestSchema("public");
+        ParserFeature parser = new ParserFeature();
+        schema.addFeature(parser);
+
+        Assert.assertEquals(2, schema.getObjectReactive(Type.object).collectList().block().size());
+        Assert.assertEquals(1, parser.parseAllReactiveCount);
+        Assert.assertEquals(2, schema.getObjectReactive(Type.object).collectList().block().size());
+        Assert.assertEquals(1, parser.parseAllReactiveCount);
+
+        AbstractSchemaMetadata cloned = schema.clone();
+        Assert.assertNotSame(schema, cloned);
+        Assert.assertSame(parser, cloned.getFeatureNow("parser"));
+        schema.addFeature(new TestFeature("newFeature", Type.other));
+        Assert.assertFalse(cloned.getFeature("newFeature").isPresent());
+    }
+
+    @Test
+    public void testColumnMetadataEncodeDecodeAndProperties() {
+        TestColumn column = new TestColumn("name");
+        column.setAlias(null);
+        column.setRealName("real_name");
+        column.setValueCodec(new PrefixCodec());
+        column.setDictionaryCodec(new SimpleDictionaryCodec());
+
+        Assert.assertEquals("name", column.getAlias());
+        Assert.assertEquals("real_name", column.getRealName());
+        Assert.assertTrue(column.realNameDetected());
+        Assert.assertEquals("dict:encoded:value", column.encode("value"));
+        Assert.assertEquals("dict:decoded:value", column.decode("encoded:value"));
+        Assert.assertEquals("encoded:null", column.encode(null));
+
+        Assert.assertNull(column.getProperty("missing").getValue());
+        Assert.assertEquals("default", column.getProperty("missing", "default").getValue());
+        Assert.assertNull(column.setProperty("k", "v").getValue());
+        Assert.assertEquals("v", column.getProperty("k").getValue());
+
+        TestFeature feature = new TestFeature("columnFeature", Type.other);
+        column.addFeature(feature);
+        Assert.assertSame(feature, column.getFeatureNow("columnFeature"));
+        Assert.assertEquals(DefaultObjectType.schema, new TestSchema("schema").getObjectType());
+        Assert.assertTrue(column.equalsNameOrAlias("NAME"));
+        Assert.assertFalse(column.equalsNameOrAlias(null));
+    }
+
+    enum Type implements ObjectType, FeatureType {
+        object("对象"),
+        metadata("元数据"),
+        other("其他");
+
+        private final String name;
+
+        Type(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getId() {
+            return name();
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    static class TestFeature implements Feature {
+        private final String id;
+        private final FeatureType type;
+
+        TestFeature(String id, FeatureType type) {
+            this.id = id;
+            this.type = type;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String getName() {
+            return id;
+        }
+
+        @Override
+        public FeatureType getType() {
+            return type;
+        }
+    }
+
+
+
+    static class OtherParserFeature extends ParserFeature {
+        OtherParserFeature() {
+            super("otherParser");
+        }
+
+        @Override
+        public ObjectType getObjectType() {
+            return Type.other;
+        }
+    }
+
+    static class ParserFeature extends TestFeature implements ObjectMetadataParser {
+        int parseAllCount;
+        int parseByNameCount;
+        int parseAllReactiveCount;
+        int parseByNameReactiveCount;
+
+        ParserFeature() {
+            this("parser");
+        }
+
+        ParserFeature(String id) {
+            super(id, DefaultFeatureType.metadataParser);
+        }
+
+        @Override
+        public ObjectType getObjectType() {
+            return Type.object;
+        }
+
+        @Override
+        public Optional<? extends ObjectMetadata> parseByName(String name) {
+            parseByNameCount++;
+            return Optional.of(new TestObject(name, name + "Alias", Type.other));
+        }
+
+        @Override
+        public List<? extends ObjectMetadata> parseAll() {
+            parseAllCount++;
+            return java.util.Arrays.asList(new TestObject("deviceA", null, Type.object),
+                                           new TestObject("deviceB", null, Type.object));
+        }
+
+        @Override
+        public Mono<? extends ObjectMetadata> parseByNameReactive(String name) {
+            parseByNameReactiveCount++;
+            return Mono.just(new TestObject(name, name + "Alias", Type.other));
+        }
+
+        @Override
+        public reactor.core.publisher.Flux<? extends ObjectMetadata> parseAllReactive() {
+            parseAllReactiveCount++;
+            return reactor.core.publisher.Flux.fromIterable(parseAll());
+        }
+    }
+
+    static class TestDatabase extends AbstractDatabaseMetadata<TestSchema> {
+        TestDatabase(String name) {
+            setName(name);
+        }
+    }
+
+    static class TestSchema extends AbstractSchemaMetadata {
+        TestSchema(String name) {
+            setName(name);
+        }
+
+        @Override
+        public List<ObjectType> getAllObjectType() {
+            return Collections.singletonList(Type.object);
+        }
+    }
+
+    static class TestObject implements ObjectMetadata {
+        private final String name;
+        private final String alias;
+        private final ObjectType objectType;
+
+        TestObject(String name, String alias, ObjectType objectType) {
+            this.name = name;
+            this.alias = alias;
+            this.objectType = objectType;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getAlias() {
+            return alias;
+        }
+
+        @Override
+        public ObjectType getObjectType() {
+            return objectType;
+        }
+
+        @Override
+        public ObjectMetadata clone() {
+            return new TestObject(name, alias, objectType);
+        }
+    }
+
+    static class TestColumn extends AbstractColumnMetadata {
+        TestColumn(String name) {
+            setName(name);
+        }
+
+        @Override
+        public ObjectType getObjectType() {
+            return Type.object;
+        }
+    }
+
+    static class PrefixCodec implements ValueCodec<String, String> {
+        @Override
+        public String encodeNull() {
+            return "encoded:null";
+        }
+
+        @Override
+        public String encode(Object value) {
+            return "encoded:" + value;
+        }
+
+        @Override
+        public String decode(Object data) {
+            return String.valueOf(data).replace("encoded:", "");
+        }
+    }
+
+    static class SimpleDictionaryCodec implements DictionaryCodec {
+        @Override
+        public Collection<Object> getItems() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getFieldName() {
+            return "dict";
+        }
+
+        @Override
+        public Object encode(Object value) {
+            return "dict:" + value;
+        }
+
+        @Override
+        public Object decode(Object data) {
+            return "dict:decoded:" + data;
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlCreateTableSqlBuilder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlCreateTableSqlBuilder.java
@@ -13,6 +13,9 @@ import org.hswebframework.ezorm.rdb.operator.builder.fragments.ddl.CreateIndexPa
 import org.hswebframework.ezorm.rdb.operator.builder.fragments.ddl.CreateIndexSqlBuilder;
 import org.hswebframework.ezorm.rdb.operator.builder.fragments.ddl.CreateTableSqlBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hswebframework.ezorm.rdb.executor.SqlRequests.of;
 
 /**
@@ -34,6 +37,7 @@ public class KingbaseMysqlCreateTableSqlBuilder implements CreateTableSqlBuilder
     @Override
     public SqlRequest build(RDBTableMetadata table) {
         DefaultBatchSqlRequest sql = new DefaultBatchSqlRequest();
+        List<SqlRequest> comments = new ArrayList<>();
 
         PrepareSqlFragments createTable = PrepareSqlFragments.of();
 
@@ -66,8 +70,8 @@ public class KingbaseMysqlCreateTableSqlBuilder implements CreateTableSqlBuilder
             }
             // 使用 PostgreSQL 标准的 COMMENT ON COLUMN 语法（作为单独的批量 SQL）
             if (column.getComment() != null) {
-                sql.addBatch(of(String.format("comment on column %s is '%s'",
-                        column.getFullTableName(), column.getComment())));
+                comments.add(of(String.format("comment on column %s is '%s'",
+                                              column.getFullTableName(), column.getComment())));
             }
         }
 
@@ -76,11 +80,12 @@ public class KingbaseMysqlCreateTableSqlBuilder implements CreateTableSqlBuilder
 
         // 使用 PostgreSQL 标准的 COMMENT ON TABLE 语法
         if (table.getComment() != null) {
-            sql.addBatch(of(String.format("comment on table %s is '%s'",
-                    table.getFullName(), table.getComment())));
+            comments.add(of(String.format("comment on table %s is '%s'",
+                                          table.getFullName(), table.getComment())));
         }
 
         sql.setSql(createTable.toRequest().getSql());
+        comments.forEach(sql::addBatch);
 
         table.findFeature(CreateIndexSqlBuilder.ID)
                 .ifPresent(builder -> {

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/CodecBranchCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/CodecBranchCoverageTest.java
@@ -1,0 +1,98 @@
+package org.hswebframework.ezorm.rdb.codec;
+
+import org.hswebframework.ezorm.core.GlobalConfig;
+import org.hswebframework.ezorm.core.ObjectPropertyOperator;
+import org.hswebframework.ezorm.core.ApacheCommonPropertyOperator;
+import org.hswebframework.ezorm.rdb.supports.json.JsonCodecSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+
+public class CodecBranchCoverageTest {
+
+    enum SampleEnum {
+        A, B
+    }
+
+    enum NamedEnum {
+        ONE("one"), TWO("two");
+
+        private final String code;
+
+        NamedEnum(String code) {
+            this.code = code;
+        }
+
+        public String getCode() {
+            return code;
+        }
+    }
+
+    @Test
+    public void testNumberCodecEncodeDecodeBranches() {
+        NumberValueCodec longCodec = new NumberValueCodec(Long.class);
+        Assert.assertNull(longCodec.encode(null));
+        Assert.assertEquals(12L, longCodec.encode("12"));
+        Assert.assertEquals(12L, longCodec.decode("12"));
+        Assert.assertEquals(1L, longCodec.encode(true));
+        Assert.assertEquals(0L, longCodec.encode(false));
+        Assert.assertEquals(10L, longCodec.encode(new BigDecimal("10")));
+        Assert.assertEquals(11L, longCodec.encode(new BigInteger("11")));
+        Assert.assertNotNull(longCodec.encode(new java.util.Date(1000)));
+        Assert.assertNotNull(longCodec.encode(java.time.LocalDateTime.of(2026, 1, 1, 0, 0)));
+        Assert.assertNotNull(longCodec.encode(java.time.ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, java.time.ZoneId.systemDefault())));
+        Assert.assertEquals(1L, longCodec.decode(true));
+        try {
+            longCodec.encode("bad-number");
+            Assert.fail("expected invalid number to fail fast");
+        } catch (Exception ignore) {
+        }
+    }
+
+    @Test
+    public void testEnumCodecMaskAndPropertyBranches() {
+        EnumValueCodec nameCodec = new EnumValueCodec(SampleEnum.class);
+        Assert.assertEquals("A", nameCodec.encode(SampleEnum.A));
+        Assert.assertEquals(SampleEnum.B, nameCodec.decode("B"));
+        Assert.assertEquals("A,B", nameCodec.encode(new SampleEnum[]{SampleEnum.A, SampleEnum.B}));
+
+        EnumValueCodec maskCodec = new EnumValueCodec(SampleEnum.class, true);
+        Assert.assertEquals(3L, maskCodec.encode(new SampleEnum[]{SampleEnum.A, SampleEnum.B}));
+        Assert.assertEquals(SampleEnum.A, maskCodec.decode(1));
+        Assert.assertEquals(SampleEnum.B, maskCodec.decode(2));
+        Assert.assertEquals(SampleEnum.A, maskCodec.decode("A"));
+
+        EnumValueCodec propCodec = new EnumValueCodec(NamedEnum.class, "code");
+        GlobalConfig.setPropertyOperator(new ObjectPropertyOperator() {
+            @Override
+            public java.util.Optional<Object> getProperty(Object object, String name) {
+                return "code".equals(name) ? java.util.Optional.of(((NamedEnum) object).getCode()) : java.util.Optional.empty();
+            }
+
+            @Override
+            public void setProperty(Object object, String name, Object value) {
+            }
+        });
+        try {
+            Assert.assertEquals("one", propCodec.encode(NamedEnum.ONE));
+            Assert.assertEquals(NamedEnum.TWO, propCodec.decode("two"));
+        } finally {
+            GlobalConfig.setPropertyOperator(ApacheCommonPropertyOperator.INSTANCE);
+        }
+
+        EnumValueCodec arrayMaskCodec = new EnumValueCodec(SampleEnum[].class, true);
+        Assert.assertTrue(arrayMaskCodec.decode(3L) instanceof SampleEnum[]);
+    }
+
+    @Test
+    public void testJsonCodecSupportArrayAndReaderBranches() throws Exception {
+        Assert.assertEquals("[1,2]", JsonCodecSupport.toJson(Arrays.asList(1, 2)));
+        Assert.assertTrue(JsonCodecSupport.canReadAsString(new StringBuilder("x")));
+        Assert.assertEquals("x", JsonCodecSupport.readAsString(new StringBuilder("x")));
+        Assert.assertEquals("abc", JsonCodecSupport.readAsString(new java.io.StringReader("abc")));
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/CompositeValueCodecTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/CompositeValueCodecTest.java
@@ -1,0 +1,26 @@
+package org.hswebframework.ezorm.rdb.codec;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CompositeValueCodecTest {
+
+    @Test
+    public void testEncodeAndDecodePipelineOrder() {
+        CompositeValueCodec codec = new CompositeValueCodec()
+            .addEncoder(value -> value + "-second")
+            .addEncoderFirst(value -> "first-" + value)
+            .addDecoder(value -> value + "-decoded2")
+            .addDecoderFirst(value -> "decoded1-" + value);
+
+        Assert.assertEquals("first-value-second", codec.encode("value"));
+        Assert.assertEquals("decoded1-value-decoded2", codec.decode("value"));
+    }
+
+    @Test
+    public void testEmptyPipelineKeepsValue() {
+        CompositeValueCodec codec = new CompositeValueCodec();
+        Assert.assertEquals("value", codec.encode("value"));
+        Assert.assertEquals("value", codec.decode("value"));
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/JsonValueCodecBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/JsonValueCodecBranchTest.java
@@ -1,0 +1,145 @@
+package org.hswebframework.ezorm.rdb.codec;
+
+import org.hswebframework.ezorm.rdb.executor.NullValue;
+import org.hswebframework.ezorm.rdb.metadata.DataType;
+import org.hswebframework.ezorm.rdb.metadata.LengthSupport;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class JsonValueCodecBranchTest {
+
+    @Test
+    public void testEncodeBranches() {
+        JsonValueCodec codec = JsonValueCodec.of(Map.class);
+        Assert.assertNull(codec.encode(null));
+        Assert.assertEquals("raw", codec.encode("raw"));
+        Assert.assertEquals("{\"name\":\"JetLinks\"}", codec.encode(Map.of("name", "JetLinks")));
+        Assert.assertEquals("{\"name\":\"JetLinks\"}", codec.encode(Map.of("name", "JetLinks"), column(new SimpleDataType("json"))));
+    }
+
+    @Test
+    public void testEncodeNullAndClobBranches() {
+        JsonValueCodec codec = JsonValueCodec.of(Map.class);
+        RDBColumnMetadata clobColumn = column(new ClobDataType());
+        RDBColumnMetadata jsonColumn = column(new SimpleDataType("json"));
+
+        Object clob = codec.encodeNull(clobColumn);
+        Assert.assertTrue(clob instanceof NullValue);
+        Assert.assertEquals(LongCharSequence.class, ((NullValue) clob).getType());
+
+        Object json = codec.encodeNull(jsonColumn);
+        Assert.assertTrue(json instanceof NullValue);
+        Assert.assertEquals(jsonColumn.getType(), ((NullValue) json).getDataType());
+        Assert.assertNull(codec.encodeNull());
+    }
+
+    @Test
+    public void testDecodeBranches() {
+        JsonValueCodec codec = JsonValueCodec.of(Map.class);
+        Assert.assertNull(codec.decode(null));
+        Assert.assertNull(codec.decode("plain"));
+        Assert.assertTrue(codec.decode("{\"a\":1}") instanceof Map);
+        Assert.assertNull(codec.decode(new byte[]{'[', '1', ',', '2', ']'}));
+        Assert.assertTrue(codec.decode(java.nio.ByteBuffer.wrap("{\"a\":1}".getBytes())) instanceof Map);
+    }
+
+    @Test
+    public void testOfFieldMonoFluxAndArrayBranches() throws Exception {
+        Assert.assertTrue(JsonValueCodec.ofField(Holder.class.getDeclaredField("list")).decode("[\"a\",\"b\"]") instanceof List);
+        Assert.assertTrue(JsonValueCodec.ofField(Holder.class.getDeclaredField("map")).decode("{\"a\":1}") instanceof Map);
+        Assert.assertNotNull(JsonValueCodec.ofField(Holder.class.getDeclaredField("mono")));
+        Assert.assertNotNull(JsonValueCodec.ofField(Holder.class.getDeclaredField("flux")));
+        Assert.assertTrue(JsonValueCodec.ofField(Holder.class.getDeclaredField("array")).decode("[\"a\",\"b\"]") instanceof String[]);
+    }
+
+    @Test
+    public void testColumnLengthAndTypeBranches() {
+        RDBTableMetadata table = new H2SchemaMetadata("PUBLIC").newTable("test_codec_branch");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("data");
+        column.setDataType("varchar(64)");
+        column.setType(new SimpleLengthDataType("varchar", 64, 10, 2));
+
+        Assert.assertEquals("varchar(64)", column.getDataType());
+        Assert.assertEquals(64, column.getLength());
+        Assert.assertEquals(10, column.getPrecision());
+        Assert.assertEquals(2, column.getScale());
+
+        column.setLength(32);
+        Assert.assertEquals(32, column.getLength());
+
+        RDBTableMetadata afterTable = new H2SchemaMetadata("PUBLIC").newTable("test_codec_branch_2");
+        RDBColumnMetadata after = afterTable.newColumn();
+        after.setName("data");
+
+        after.setType(new SimpleLengthDataType("varchar", 128, 12, 3));
+        table.addColumn(column);
+        afterTable.addColumn(after);
+        Assert.assertTrue(column.ddlModifiable(after));
+        Assert.assertFalse(after.ddlModifiable(after));
+    }
+
+    private static RDBColumnMetadata column(DataType type) {
+        RDBTableMetadata table = new H2SchemaMetadata("PUBLIC").newTable("test_codec_branch");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("data");
+        column.setType(type);
+        return column;
+    }
+
+    public static class Holder {
+        private List<String> list;
+        private Map<String, Integer> map;
+        private reactor.core.publisher.Mono<String> mono;
+        private reactor.core.publisher.Flux<String> flux;
+        private String[] array;
+    }
+
+    private record SimpleDataType(String id) implements DataType {
+        @Override public String getId() { return id; }
+        @Override public String getName() { return id; }
+        @Override public java.sql.SQLType getSqlType() { return java.sql.JDBCType.VARCHAR; }
+        @Override public Class<?> getJavaType() { return Object.class; }
+    }
+
+    private record ClobDataType() implements DataType, LengthSupport {
+        @Override public String getId() { return "clob"; }
+        @Override public String getName() { return "clob"; }
+        @Override public java.sql.SQLType getSqlType() { return java.sql.JDBCType.CLOB; }
+        @Override public Class<?> getJavaType() { return Object.class; }
+        @Override public int getLength() { return 0; }
+        @Override public int getScale() { return 0; }
+        @Override public int getPrecision() { return 0; }
+    }
+
+    private record SimpleLengthDataType(String id, int length, int precision, int scale) implements DataType, LengthSupport {
+        @Override public String getId() { return id; }
+        @Override public String getName() { return id; }
+        @Override public java.sql.SQLType getSqlType() { return java.sql.JDBCType.VARCHAR; }
+        @Override public Class<?> getJavaType() { return Object.class; }
+        @Override public int getLength() { return length; }
+        @Override public int getScale() { return scale; }
+        @Override public int getPrecision() { return precision; }
+    }
+
+
+    @Test
+    public void testDecodeInputStreamReaderClobBlobAndFallbackBranches() throws Exception {
+        JsonValueCodec codec = JsonValueCodec.of(Map.class);
+        String json = "{\"a\":1}";
+        Assert.assertTrue(codec.decode(new java.io.ByteArrayInputStream(json.getBytes())) instanceof Map);
+        Assert.assertTrue(codec.decode(new java.io.StringReader(json)) instanceof Map);
+        Assert.assertTrue(codec.decode(new javax.sql.rowset.serial.SerialClob(json.toCharArray())) instanceof Map);
+        Assert.assertTrue(codec.decode(new javax.sql.rowset.serial.SerialBlob(json.getBytes())) instanceof Map);
+        Assert.assertTrue(codec.decode(io.r2dbc.spi.Blob.from(reactor.core.publisher.Mono.just(java.nio.ByteBuffer.wrap(json.getBytes())))) instanceof Map);
+        Assert.assertTrue(codec.decode(io.r2dbc.spi.Clob.from(reactor.core.publisher.Flux.just(json))) instanceof Map);
+        Object fallback = codec.decode(new Object());
+        Assert.assertSame(fallback, fallback);
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/JsonValueCodecIoBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/codec/JsonValueCodecIoBranchTest.java
@@ -1,0 +1,100 @@
+package org.hswebframework.ezorm.rdb.codec;
+
+import org.hswebframework.ezorm.rdb.executor.NullValue;
+import org.hswebframework.ezorm.rdb.metadata.DataType;
+import org.hswebframework.ezorm.rdb.metadata.LengthSupport;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.sql.rowset.serial.SerialBlob;
+import javax.sql.rowset.serial.SerialClob;
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+public class JsonValueCodecIoBranchTest {
+
+    @Test
+    public void testDecodeClobBlobInputStreamReaderAndByteBuffer() throws Exception {
+        JsonValueCodec codec = JsonValueCodec.of(Map.class);
+        Assert.assertTrue(codec.decode(new SerialClob("{\"name\":1}".toCharArray())) instanceof Map);
+        Assert.assertTrue(codec.decode(new SerialBlob("{\"name\":2}".getBytes())) instanceof Map);
+        Assert.assertTrue(codec.decode(new ByteArrayInputStream("{\"name\":3}".getBytes())) instanceof Map);
+        Assert.assertTrue(codec.decode(new StringReader("{\"name\":4}")) instanceof Map);
+        Assert.assertTrue(codec.decode(ByteBuffer.wrap("{\"name\":5}".getBytes())) instanceof Map);
+        Assert.assertTrue(codec.decode("{\"name\":6}") instanceof Map);
+    }
+
+    @Test
+    public void testEncodeNullAndEncodeWithClobColumnBranches() {
+        JsonValueCodec codec = JsonValueCodec.of(Map.class);
+        RDBColumnMetadata clob = column(new ClobLikeType());
+        Object encodedNull = codec.encodeNull(clob);
+        Assert.assertTrue(encodedNull instanceof NullValue);
+        Assert.assertEquals(LongCharSequence.class, ((NullValue) encodedNull).getType());
+
+        Object encoded = codec.encode(Map.of("name", "JetLinks"), clob);
+        Assert.assertTrue(encoded instanceof LongCharSequence);
+        Assert.assertTrue(encoded.toString().contains("JetLinks"));
+
+        Assert.assertEquals("raw", String.valueOf(codec.encode("raw", clob)));
+    }
+
+    @Test
+    public void testTargetTypePreservesInstanceAndCollectionFactory() {
+        JsonValueCodec codec = JsonValueCodec.ofCollection(List.class, String.class);
+        Assert.assertTrue(codec.decode("[\"a\",\"b\"]") instanceof List);
+        Assert.assertEquals("[\"a\",\"b\"]", codec.encode(List.of("a", "b")));
+    }
+
+    private static RDBColumnMetadata column(DataType type) {
+        RDBTableMetadata table = new H2SchemaMetadata("PUBLIC").newTable("json_codec_branch");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("data");
+        column.setType(type);
+        return column;
+    }
+
+    private record ClobLikeType() implements DataType, LengthSupport {
+        @Override
+        public String getId() {
+            return "clob";
+        }
+
+        @Override
+        public String getName() {
+            return "clob";
+        }
+
+        @Override
+        public java.sql.SQLType getSqlType() {
+            return java.sql.JDBCType.CLOB;
+        }
+
+        @Override
+        public Class<?> getJavaType() {
+            return Object.class;
+        }
+
+        @Override
+        public int getLength() {
+            return 0;
+        }
+
+        @Override
+        public int getScale() {
+            return 0;
+        }
+
+        @Override
+        public int getPrecision() {
+            return 0;
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/mapping/defaults/DefaultQueryUpdateCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/mapping/defaults/DefaultQueryUpdateCoverageTest.java
@@ -1,0 +1,160 @@
+package org.hswebframework.ezorm.rdb.mapping.defaults;
+
+import org.hswebframework.ezorm.core.param.QueryParam;
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.hswebframework.ezorm.core.param.UpdateParam;
+import org.hswebframework.ezorm.rdb.TestSyncSqlExecutor;
+import org.hswebframework.ezorm.rdb.mapping.EntityColumnMapping;
+import org.hswebframework.ezorm.rdb.mapping.MappingFeatureType;
+import org.hswebframework.ezorm.rdb.mapping.TestEntity;
+import org.hswebframework.ezorm.rdb.mapping.jpa.JpaEntityTableMetadataParser;
+import org.hswebframework.ezorm.rdb.mapping.wrapper.EntityResultWrapper;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.operator.DefaultDatabaseOperator;
+import org.hswebframework.ezorm.rdb.operator.dml.query.SortOrder;
+import org.hswebframework.ezorm.rdb.supports.h2.H2ConnectionProvider;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+
+public class DefaultQueryUpdateCoverageTest {
+
+    private DefaultSyncRepository<TestEntity, String> repository;
+
+    @Before
+    public void init() {
+        RDBDatabaseMetadata databaseMetadata = new RDBDatabaseMetadata(Dialect.H2);
+        H2SchemaMetadata h2 = new H2SchemaMetadata("PUBLIC");
+        databaseMetadata.setCurrentSchema(h2);
+        databaseMetadata.addSchema(h2);
+        databaseMetadata.addFeature(new TestSyncSqlExecutor(new H2ConnectionProvider()));
+
+        DefaultDatabaseOperator operator = DefaultDatabaseOperator.of(databaseMetadata);
+        operator.ddl()
+            .createOrAlter("entity_test")
+            .addColumn("id").primaryKey().varchar(32).commit()
+            .addColumn("name").varchar(32).commit()
+            .addColumn("state").number(4).commit()
+            .addColumn("create_time").alias("createTime").datetime().commit()
+            .commit()
+            .sync();
+
+        JpaEntityTableMetadataParser parser = new JpaEntityTableMetadataParser();
+        parser.setDatabaseMetadata(databaseMetadata);
+        RDBTableMetadata table = parser.parseTableMetadata(TestEntity.class).orElseThrow(NullPointerException::new);
+        h2.addTable(table);
+
+        EntityResultWrapper<TestEntity> wrapper = new EntityResultWrapper<>(TestEntity::new);
+        wrapper.setMapping(table.<EntityColumnMapping>getFeature(MappingFeatureType.columnPropertyMapping.createFeatureId(TestEntity.class))
+                                .orElseThrow(NullPointerException::new));
+
+        repository = new DefaultSyncRepository<>(DefaultDatabaseOperator.of(databaseMetadata), table, TestEntity.class, wrapper);
+    }
+
+    @Test
+    public void testQueryBranches() {
+        repository.save(entity("q1", "alpha", (byte) 1));
+        repository.save(entity("q2", "beta", (byte) 2));
+
+        QueryParam param = repository.createQuery()
+            .select("id", "name", "createTime")
+            .selectExcludes("createTime")
+            .context("traceId", "trace-1")
+            .orderBy(SortOrder.desc("name"))
+            .paging(0, 1)
+            .getParam();
+        Assert.assertEquals("trace-1", param.getContext("traceId").orElse(null));
+        Assert.assertEquals(1, param.getPageSize());
+        Assert.assertTrue(param.isPaging());
+        Assert.assertEquals(0, param.getSorts().size());
+        Assert.assertFalse(param.isForUpdate());
+
+        List<TestEntity> page = repository.createQuery()
+            .select("id", "name", "createTime")
+            .selectExcludes("createTime")
+            .context("traceId", "trace-1")
+            .orderBy(SortOrder.desc("name"))
+            .paging(0, 1)
+            .fetch();
+        Assert.assertEquals(1, page.size());
+        Assert.assertNull(page.get(0).getCreateTime());
+
+        Assert.assertEquals("alpha", repository.createQuery()
+            .select("id", "name")
+            .where("id", "q1")
+            .fetchOne()
+            .orElseThrow(NullPointerException::new)
+            .getName());
+
+        Assert.assertEquals(2, repository.createQuery()
+            .where()
+            .and("state", TermType.gte, 1)
+            .count());
+
+        Assert.assertEquals(1, repository.createQuery()
+            .where("id", "q1")
+            .forUpdate()
+            .fetch()
+            .size());
+
+        QueryParam manual = new QueryParam();
+        manual.setPaging(false);
+        manual.getTerms().add(Term.of("id", TermType.eq, "q1"));
+        Assert.assertSame(manual, repository.createQuery().setParam(manual).getParam());
+    }
+
+    @Test
+    public void testUpdateBranches() {
+        TestEntity source = entity("u1", "before", (byte) 1);
+        repository.save(source);
+
+        Assert.assertEquals(1, repository.createUpdate()
+            .set(source)
+            .includes("name")
+            .where("id", "u1")
+            .execute());
+        Assert.assertEquals("before", repository.findById("u1").orElseThrow(NullPointerException::new).getName());
+
+        Assert.assertEquals(1, repository.createUpdate()
+            .set("name", "after")
+            .setNull("createTime")
+            .where("id", "u1")
+            .execute());
+        TestEntity updated = repository.findById("u1").orElseThrow(NullPointerException::new);
+        Assert.assertEquals("after", updated.getName());
+        Assert.assertNull(updated.getCreateTime());
+
+        UpdateParam<TestEntity> param = new UpdateParam<>(entity("u1", "param", (byte) 3));
+        param.getIncludes().add("name");
+        param.getExcludes().add("state");
+        param.getTerms().add(Term.of("id", TermType.eq, "u1"));
+        Assert.assertEquals(1, repository.createUpdate().accept(param).execute());
+
+        updated = repository.findById("u1").orElseThrow(NullPointerException::new);
+        Assert.assertEquals("param", updated.getName());
+        Assert.assertEquals(Byte.valueOf((byte) 1), updated.getState());
+
+        Assert.assertEquals(0, repository.updateById(null, source));
+        Assert.assertEquals(0, repository.updateById("u1", null));
+        Assert.assertEquals(0, repository.deleteById((java.util.Collection<String>) null));
+        Assert.assertEquals(0, repository.deleteById(java.util.Collections.emptyList()));
+        Assert.assertTrue(repository.findById((String) null).isEmpty());
+        Assert.assertTrue(repository.findById(java.util.Collections.emptyList()).isEmpty());
+    }
+
+    private TestEntity entity(String id, String name, Byte state) {
+        TestEntity entity = new TestEntity();
+        entity.setId(id);
+        entity.setName(name);
+        entity.setState(state);
+        entity.setCreateTime(new Date());
+        return entity;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/mapping/defaults/record/DefaultRecordBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/mapping/defaults/record/DefaultRecordBranchTest.java
@@ -1,0 +1,68 @@
+package org.hswebframework.ezorm.rdb.mapping.defaults.record;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+public class DefaultRecordBranchTest {
+
+    @Test
+    public void testTypedAccessAndNullSkipping() {
+        Date now = new Date();
+        Record record = Record.newRecord()
+            .putValue("name", "JetLinks")
+            .putValue("age", 18)
+            .putValue("enabledNumber", 1)
+            .putValue("enabledTrue", true)
+            .putValue("enabledY", "Y")
+            .putValue("enabledLowerY", "y")
+            .putValue("enabledOne", "1")
+            .putValue("created", now)
+            .putValue("ignored", null);
+
+        Assert.assertEquals("JetLinks", record.getString("name").orElse(null));
+        Assert.assertEquals(Integer.valueOf(18), record.getInteger("age").orElse(null));
+        Assert.assertTrue(record.getBoolean("enabledNumber").orElse(false));
+        Assert.assertTrue(record.getBoolean("enabledTrue").orElse(false));
+        Assert.assertTrue(record.getBoolean("enabledY").orElse(false));
+        Assert.assertTrue(record.getBoolean("enabledLowerY").orElse(false));
+        Assert.assertTrue(record.getBoolean("enabledOne").orElse(false));
+        Assert.assertEquals(now, record.getDate("created").orElse(null));
+        Assert.assertFalse(record.containsKey("ignored"));
+        Assert.assertFalse(record.get("missing").isPresent());
+    }
+
+    @Test
+    public void testNestAndNestsBranches() {
+        Record child = Record.newRecord().putValue("name", "child");
+        Map<String, Object> childMap = new LinkedHashMap<>();
+        childMap.put("name", "mapChild");
+        List<Record> children = Arrays.asList(child, Record.newRecord(childMap));
+
+        Record record = Record.newRecord()
+            .putValue("childRecord", child)
+            .putValue("childMap", childMap)
+            .putValue("children", children);
+
+        Assert.assertSame(child, record.getNest("childRecord").orElseThrow());
+        Assert.assertEquals("mapChild", record.getNest("childMap").orElseThrow().getString("name").orElse(null));
+        Assert.assertEquals(1, record.getNests("childRecord").orElseThrow().size());
+        Assert.assertEquals(1, record.getNests("childMap").orElseThrow().size());
+        Assert.assertEquals(2, record.getNests("children").orElseThrow().size());
+        Assert.assertEquals("child", record.apply(r -> r.getNest("childRecord").orElseThrow().getString("name").orElse(null)));
+        final boolean[] accepted = {false};
+        record.accept(r -> accepted[0] = r.containsKey("children"));
+        Assert.assertTrue(accepted[0]);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testInvalidNestFailsFast() {
+        Record.newRecord().putValue("bad", "text").getNest("bad");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testInvalidNestsFailsFast() {
+        Record.newRecord().putValue("bad", "text").getNests("bad");
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/metadata/RDBColumnMetadataBehaviorTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/metadata/RDBColumnMetadataBehaviorTest.java
@@ -1,0 +1,249 @@
+package org.hswebframework.ezorm.rdb.metadata;
+
+import org.hswebframework.ezorm.core.RuntimeDefaultValue;
+import org.hswebframework.ezorm.core.meta.Feature;
+import org.hswebframework.ezorm.core.meta.DefaultFeatureType;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.JDBCType;
+import java.util.Optional;
+
+public class RDBColumnMetadataBehaviorTest {
+
+    @Test
+    public void testDerivedLengthPrecisionJavaTypeAndNotNull() {
+        RDBTableMetadata table = createTable();
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("amount");
+        column.setOwner(table);
+        column.setType(JdbcDataType.of(JDBCType.DECIMAL, Number.class));
+
+        Assert.assertEquals(10, column.getLength(10));
+        Assert.assertEquals(0, column.getLength());
+        Assert.assertEquals(18, column.getPrecision(18));
+        Assert.assertEquals(0, column.getPrecision());
+        Assert.assertEquals(Number.class, column.getJavaType());
+        Assert.assertFalse(column.isNotNull());
+
+        column.setPrimaryKey(true);
+        Assert.assertTrue(column.isNotNull());
+    }
+
+    @Test
+    public void testLengthSupportTypePopulatesLengthPrecisionScale() {
+        RDBTableMetadata table = createTable();
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("name");
+        column.setOwner(table);
+        column.setType(new LengthType());
+
+        Assert.assertEquals(32, column.getLength());
+        Assert.assertEquals(18, column.getPrecision());
+        Assert.assertEquals(6, column.getScale());
+        Assert.assertEquals("length(32)", column.getDataType());
+    }
+
+    @Test
+    public void testDdlModifiableAndGenerateDefaultValue() {
+        RDBTableMetadata table = createTable();
+        RDBColumnMetadata before = table.newColumn();
+        before.setName("score");
+        before.setOwner(table);
+        before.setType(JdbcDataType.of(JDBCType.DECIMAL, Number.class));
+        before.setPrecision(10);
+        before.setScale(2);
+        before.getPreviousName();
+
+        RDBColumnMetadata same = before.clone();
+        same.setOwner(table);
+        same.setType(JdbcDataType.of(JDBCType.DECIMAL, Number.class));
+        same.setPrecision(10);
+        same.setScale(2);
+        Assert.assertFalse(before.ddlModifiable(same));
+
+        RDBColumnMetadata larger = before.clone();
+        larger.setOwner(table);
+        larger.setType(JdbcDataType.of(JDBCType.DECIMAL, Number.class));
+        larger.setPrecision(12);
+        larger.setScale(4);
+        Assert.assertTrue(before.ddlModifiable(larger));
+
+        RDBColumnMetadata renamed = before.clone();
+        renamed.setOwner(table);
+        renamed.setName("score_new");
+        Assert.assertFalse(before.ddlModifiable(renamed));
+
+        RDBColumnMetadata defaultValueColumn = table.newColumn();
+        defaultValueColumn.setName("created_at");
+        defaultValueColumn.setOwner(table);
+        defaultValueColumn.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        defaultValueColumn.setDefaultValue((RuntimeDefaultValue) () -> "2026-05-26 12:00:00");
+        Assert.assertEquals(Optional.of("2026-05-26 12:00:00"), defaultValueColumn.generateDefaultValue());
+    }
+
+    @Test
+    public void testToStringFeatureAndFullNameBranches() {
+        RDBTableMetadata table = createTable();
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("nick_name");
+        column.setAlias("nick.name");
+        column.setComment("昵称");
+        column.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        table.addColumn(column);
+
+        Assert.assertTrue(column.toString().contains("nick_name"));
+        Assert.assertTrue(column.toString().contains("String"));
+        Assert.assertTrue(column.toString().contains("昵称"));
+        Assert.assertEquals(column.getFullName(), column.getFullName(null));
+        Assert.assertEquals(column.getFullName(), column.getFullName(""));
+        Assert.assertTrue(column.getFullName("alias").contains("alias"));
+        Assert.assertTrue(column.getFullTableName().contains("test_column_behavior"));
+        Assert.assertEquals(RDBObjectType.column, column.getObjectType());
+
+        Feature feature = new SimpleFeature("column-feature");
+        column.addFeature(feature);
+        Assert.assertSame(feature, column.findFeatureOrElse("column-feature", () -> null));
+        Assert.assertEquals(1, column.findFeatures(f -> f.getId().equals("column-feature")).size());
+    }
+
+    @Test
+    public void testDdlModifiableLengthScaleAndNotNullBranches() {
+        RDBTableMetadata table = createTable();
+        RDBColumnMetadata before = table.newColumn();
+        before.setName("name");
+        before.setOwner(table);
+        before.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        before.setLength(16);
+        before.getPreviousName();
+
+        RDBColumnMetadata longer = before.clone();
+        longer.setOwner(table);
+        longer.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        longer.setLength(32);
+        Assert.assertTrue(before.ddlModifiable(longer));
+
+        RDBColumnMetadata shorter = before.clone();
+        shorter.setOwner(table);
+        shorter.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        shorter.setLength(8);
+        Assert.assertFalse(before.ddlModifiable(shorter));
+
+        RDBColumnMetadata notNull = before.clone();
+        notNull.setOwner(table);
+        notNull.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        notNull.setNotNull(true);
+        Assert.assertTrue(before.ddlModifiable(notNull));
+
+        RDBColumnMetadata scaleBefore = table.newColumn();
+        scaleBefore.setName("amount");
+        scaleBefore.setOwner(table);
+        scaleBefore.setType(new ScaleOnlyType());
+        scaleBefore.setScale(2);
+        scaleBefore.setDataType(null);
+        RDBColumnMetadata scaleAfter = scaleBefore.clone();
+        scaleAfter.setOwner(table);
+        scaleAfter.setType(new ScaleOnlyType());
+        scaleAfter.setScale(4);
+        scaleAfter.setDataType(null);
+        Assert.assertFalse(scaleBefore.ddlModifiable(scaleAfter));
+    }
+
+    private RDBTableMetadata createTable() {
+        RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.H2);
+        RDBSchemaMetadata schema = new H2SchemaMetadata("PUBLIC");
+        database.addSchema(schema);
+        database.setCurrentSchema(schema);
+        RDBTableMetadata table = schema.newTable("test_column_behavior");
+        schema.addTable(table);
+        return table;
+    }
+
+    private static class LengthType implements DataType, LengthSupport, org.hswebframework.ezorm.rdb.metadata.dialect.DataTypeBuilder {
+        @Override
+        public String getId() {
+            return "length";
+        }
+
+        @Override
+        public String getName() {
+            return "length";
+        }
+
+        @Override
+        public java.sql.SQLType getSqlType() {
+            return JDBCType.VARCHAR;
+        }
+
+        @Override
+        public Class<?> getJavaType() {
+            return String.class;
+        }
+
+        @Override
+        public int getLength() {
+            return 32;
+        }
+
+        @Override
+        public int getScale() {
+            return 6;
+        }
+
+        @Override
+        public int getPrecision() {
+            return 18;
+        }
+
+        @Override
+        public String createColumnDataType(RDBColumnMetadata columnMetaData) {
+            return "length(" + columnMetaData.getLength(32) + ")";
+        }
+    }
+
+    private record SimpleFeature(String id) implements Feature {
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String getName() {
+            return id;
+        }
+
+        @Override
+        public org.hswebframework.ezorm.core.FeatureType getType() {
+            return DefaultFeatureType.metadataParser;
+        }
+    }
+
+    private static class ScaleOnlyType implements DataType {
+        @Override
+        public String getId() {
+            return "scale-only";
+        }
+
+        @Override
+        public String getName() {
+            return "scale-only";
+        }
+
+        @Override
+        public java.sql.SQLType getSqlType() {
+            return JDBCType.OTHER;
+        }
+
+        @Override
+        public Class<?> getJavaType() {
+            return String.class;
+        }
+
+        @Override
+        public boolean isScaleSupport() {
+            return true;
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/MetadataHelper.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/MetadataHelper.java
@@ -24,32 +24,26 @@ public class MetadataHelper {
         schema.addTable(table);
         schema.addTable(detail);
 
-        {
-            RDBColumnMetadata id = new RDBColumnMetadata();
-            id.setName("id");
-            id.setType(JdbcDataType.of(JDBCType.VARCHAR,String.class));
-            id.setLength(32);
+        RDBColumnMetadata id = new RDBColumnMetadata();
+        id.setName("id");
+        id.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        id.setLength(32);
 
-            RDBColumnMetadata name = new RDBColumnMetadata();
-            name.setName("name");
-            name.setType(JdbcDataType.of(JDBCType.VARCHAR,String.class));
-            name.setLength(64);
+        RDBColumnMetadata name = new RDBColumnMetadata();
+        name.setName("name");
+        name.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        name.setLength(64);
 
-            table.addColumn(id);
-            table.addColumn(name);
+        table.addColumn(id);
+        table.addColumn(name);
 
-            detail.addColumn(id.clone());
-        }
-        {
+        RDBColumnMetadata comment = new RDBColumnMetadata();
+        comment.setName("comment");
+        comment.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        comment.setLength(64);
 
-            RDBColumnMetadata comment = new RDBColumnMetadata();
-            comment.setName("comment");
-            comment.setType(JdbcDataType.of(JDBCType.VARCHAR,String.class));
-            comment.setLength(64);
-
-            detail.addColumn(comment);
-
-        }
+        table.addColumn(comment);
+        detail.addColumn(id.clone());
 
 
         return schema;

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/SelectColumnFragmentBuilderCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/SelectColumnFragmentBuilderCoverageTest.java
@@ -1,0 +1,109 @@
+package org.hswebframework.ezorm.rdb.operator.builder.fragments;
+
+import org.hswebframework.ezorm.rdb.metadata.*;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.metadata.key.ForeignKeyBuilder;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.query.SelectColumnFragmentBuilder;
+import org.hswebframework.ezorm.rdb.operator.dml.Join;
+import org.hswebframework.ezorm.rdb.operator.dml.query.NativeSelectColumn;
+import org.hswebframework.ezorm.rdb.operator.dml.query.QueryOperatorParameter;
+import org.hswebframework.ezorm.rdb.operator.dml.query.SelectColumn;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.JDBCType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+public class SelectColumnFragmentBuilderCoverageTest {
+
+    private RDBSchemaMetadata schema;
+    private RDBTableMetadata table;
+    private RDBTableMetadata detail;
+    private RDBTableMetadata detail2;
+    private SelectColumnFragmentBuilder builder;
+
+    @Before
+    public void init() {
+        RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.H2);
+        schema = new RDBSchemaMetadata("DEFAULT");
+        database.setCurrentSchema(schema);
+        database.addSchema(schema);
+        table = schema.newTable("test");
+        detail = schema.newTable("detail");
+        detail2 = schema.newTable("detail2");
+        schema.addTable(table);
+        schema.addTable(detail);
+        schema.addTable(detail2);
+        addColumn(table, "id");
+        addColumn(table, "name");
+        addColumn(detail, "comment");
+        addColumn(detail2, "comment");
+        table.addForeignKey(ForeignKeyBuilder.builder().target("detail").autoJoin(true).build().addColumn("id", "comment"));
+        builder = SelectColumnFragmentBuilder.of(table);
+    }
+
+    @Test
+    public void testDefaultAndExcludesAndAliasBranches() {
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.getSelectExcludes().add("name");
+        Assert.assertEquals("test.\"ID\" as \"id\"", builder.createFragments(parameter).toRequest().getSql());
+
+        QueryOperatorParameter aliasParameter = new QueryOperatorParameter();
+        aliasParameter.setFrom("test");
+        aliasParameter.getAlias().add(SelectColumn.of("name", "displayName"));
+        aliasParameter.getWhere().add(org.hswebframework.ezorm.core.param.Term.of("displayName", "eq", "JetLinks"));
+        String aliasSql = builder.createFragments(aliasParameter).toRequest().getSql();
+        Assert.assertTrue(aliasSql.contains("test.\"ID\" as \"id\""));
+        Assert.assertTrue(aliasSql.contains("test.\"NAME\" as \"name\""));
+
+        QueryOperatorParameter nativeParameter = new QueryOperatorParameter();
+        NativeSelectColumn nativeColumn = new NativeSelectColumn("coalesce(?, test.\"NAME\")", new Object[]{"fallback"});
+        nativeColumn.setAlias("displayName");
+        nativeParameter.setSelect(Collections.singletonList(nativeColumn));
+        Assert.assertEquals("coalesce(?, test.\"NAME\") as \"DISPLAYNAME\"", builder.createFragments(nativeParameter).toRequest().getSql());
+    }
+
+    @Test
+    public void testJoinWildcardAutoJoinAndUnknownBranch() {
+        Join join = new Join();
+        join.setTarget("detail2");
+        join.setAlias("info");
+
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.getJoins().add(join);
+        parameter.setSelect(Arrays.asList(SelectColumn.of("*") , SelectColumn.of("detail.*"), SelectColumn.of("info.comment"), SelectColumn.of("unknown.*")));
+        String sql = builder.createFragments(parameter).toRequest().getSql();
+        Assert.assertTrue(sql.contains("test.\"ID\""));
+        Assert.assertTrue(sql.contains("detail.\"COMMENT\""));
+        Assert.assertTrue(sql.contains("info.\"COMMENT\""));
+    }
+
+    @Test
+    public void testFunctionBranchesAndFallbackAlias() {
+        table.addFeature(new org.hswebframework.ezorm.rdb.operator.builder.fragments.function.SimpleFunctionFragmentBuilder("sum", "sum"));
+        SelectColumn sum = new SelectColumn();
+        sum.setColumn("id");
+        sum.setAlias("totalId");
+        sum.setFunction("sum");
+        sum.setOpts(Collections.singletonMap("distinct", true));
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.setSelect(Collections.singletonList(sum));
+        Assert.assertTrue(builder.createFragments(parameter).toRequest().getSql().contains("sum( distinct test.\"ID\" ) as \"totalId\""));
+
+        SelectColumn unknownFunction = new SelectColumn();
+        unknownFunction.setColumn("id");
+        unknownFunction.setFunction("missing_function");
+        parameter.setSelect(Collections.singletonList(unknownFunction));
+        Assert.assertTrue(builder.createFragments(parameter).isEmpty());
+    }
+
+    private void addColumn(RDBTableMetadata table, String name) {
+        RDBColumnMetadata column = table.newColumn();
+        column.setName(name);
+        column.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        table.addColumn(column);
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/SelectColumnFragmentBuilderTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/SelectColumnFragmentBuilderTest.java
@@ -1,12 +1,15 @@
 package org.hswebframework.ezorm.rdb.operator.builder.fragments;
 
 import org.hswebframework.ezorm.rdb.metadata.*;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
 import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
 import org.hswebframework.ezorm.rdb.metadata.key.ForeignKeyBuilder;
 import org.hswebframework.ezorm.rdb.operator.builder.fragments.query.SelectColumnFragmentBuilder;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.function.SimpleFunctionFragmentBuilder;
 import org.hswebframework.ezorm.rdb.operator.dml.query.QueryOperatorParameter;
 import org.hswebframework.ezorm.rdb.operator.dml.Join;
 import org.hswebframework.ezorm.rdb.operator.dml.query.SelectColumn;
+import org.hswebframework.ezorm.rdb.operator.dml.query.NativeSelectColumn;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,6 +24,8 @@ public class SelectColumnFragmentBuilderTest {
 
     SelectColumnFragmentBuilder builder;
 
+    RDBTableMetadata table;
+
     @Before
     public void init() {
         RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.H2);
@@ -30,6 +35,7 @@ public class SelectColumnFragmentBuilderTest {
         database.addSchema(schema);
 
         RDBTableMetadata test =schema.newTable("test");
+        table = test;
         RDBTableMetadata detail = schema.newTable("detail");
         RDBTableMetadata detail2 = schema.newTable("detail2");
 
@@ -178,4 +184,79 @@ public class SelectColumnFragmentBuilderTest {
         Assert.assertTrue(sql.contains("info.comment"));
 
     }
+    @Test
+    public void testDefaultSelectUsesAllColumnsAndAliasExcludes() {
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.getSelectExcludes().add("name");
+
+        SqlFragments fragments = builder.createFragments(parameter);
+        Assert.assertEquals("test.\"ID\" as \"id\"", fragments.toRequest().getSql());
+    }
+
+    @Test
+    public void testNativeSelectColumnPreservesParametersAndAlias() {
+        NativeSelectColumn nativeColumn = new NativeSelectColumn("coalesce(?, test.\"NAME\")", new Object[]{"fallback"});
+        nativeColumn.setAlias("displayName");
+
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.setSelect(Collections.singletonList(nativeColumn));
+
+        SqlRequest request = builder.createFragments(parameter).toRequest();
+        Assert.assertEquals("coalesce(?, test.\"NAME\") as \"DISPLAYNAME\"", request.getSql());
+        Assert.assertArrayEquals(new Object[]{"fallback"}, request.getParameters());
+    }
+
+    @Test
+    public void testFunctionBranchesForDistinctUnknownAndEmptyFunction() {
+        table.addFeature(new SimpleFunctionFragmentBuilder("sum", "合计"));
+
+        SelectColumn sum = new SelectColumn();
+        sum.setColumn("id");
+        sum.setAlias("totalId");
+        sum.setFunction("sum");
+        sum.setOpts(Collections.singletonMap("distinct", true));
+
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.setSelect(Collections.singletonList(sum));
+        Assert.assertEquals("sum( distinct test.\"ID\" ) as \"totalId\"",
+                            builder.createFragments(parameter).toRequest().getSql());
+
+        SelectColumn unknownFunction = new SelectColumn();
+        unknownFunction.setColumn("id");
+        unknownFunction.setFunction("missing_function");
+        parameter.setSelect(Collections.singletonList(unknownFunction));
+        Assert.assertTrue(builder.createFragments(parameter).isEmpty());
+
+        SelectColumn emptyFunction = new SelectColumn();
+        emptyFunction.setFunction("sum");
+        parameter.setSelect(Collections.singletonList(emptyFunction));
+        try {
+            builder.createFragments(parameter);
+            Assert.fail("empty function fragment should fail fast");
+        } catch (UnsupportedOperationException e) {
+            Assert.assertTrue(e.getMessage().contains("unsupported function"));
+        }
+    }
+
+    @Test
+    public void testJoinWildcardUnknownAliasAndForeignKeyAutoJoinBranches() {
+        Join join = new Join();
+        join.setTarget("detail2");
+        join.setAlias("info");
+
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.getJoins().add(join);
+        parameter.setSelect(Arrays.asList(of("unknown.*"), of("test.*"), of("info.*"), of("detail.comment")));
+        parameter.getSelectExcludes().add("id");
+
+        SqlRequest request = builder.createFragments(parameter).toRequest();
+        String sql = request.getSql();
+        Assert.assertFalse(sql.contains("unknown"));
+        Assert.assertFalse(sql.contains("ID"));
+        Assert.assertTrue(sql.contains("test.\"NAME\" as \"name\""));
+        Assert.assertTrue(sql.contains("info.\"COMMENT\" as \"info.comment\""));
+        Assert.assertTrue(sql.contains("detail.\"COMMENT\" as \"detail.comment\""));
+        Assert.assertFalse(parameter.getJoins().isEmpty());
+    }
+
 }

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/insert/MultiInsertSqlBuilderBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/insert/MultiInsertSqlBuilderBranchTest.java
@@ -1,0 +1,52 @@
+package org.hswebframework.ezorm.rdb.operator.builder.fragments.insert;
+
+import org.hswebframework.ezorm.core.RuntimeDefaultValue;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.operator.builder.MetadataHelper;
+import org.hswebframework.ezorm.rdb.operator.dml.insert.InsertColumn;
+import org.hswebframework.ezorm.rdb.operator.dml.insert.InsertOperatorParameter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class MultiInsertSqlBuilderBranchTest {
+    private MultiInsertSqlBuilder builder;
+    private RDBSchemaMetadata schema;
+
+    @Before
+    public void init() {
+        schema = MetadataHelper.createMockSchema();
+        builder = MultiInsertSqlBuilder.of(schema.getTable("test").orElseThrow(NullPointerException::new));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoOperableColumnsFailsFast() {
+        builder.build(new InsertOperatorParameter());
+    }
+
+    @Test
+    public void testRuntimeDefaultNativeAndNullBranches() {
+        schema.getTable("test").orElseThrow().getColumn("id").ifPresent(column -> column.setDefaultValue((RuntimeDefaultValue) () -> "generated-id"));
+        schema.getTable("test").orElseThrow().getColumn("comment").ifPresent(column -> column.setDefaultValue((RuntimeDefaultValue) () -> "fallback-comment"));
+
+        InsertOperatorParameter parameter = new InsertOperatorParameter();
+        parameter.getColumns().add(insertColumn("id"));
+        parameter.getColumns().add(insertColumn("name"));
+        parameter.getColumns().add(insertColumn("comment"));
+        parameter.getValues().add(Arrays.asList(null, "JetLinks", org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql.of("upper(?)", "x")));
+
+        SqlRequest request = builder.build(parameter);
+        Assert.assertTrue(request.getSql().startsWith("insert into \"PUBLIC\".test"));
+        Assert.assertArrayEquals(new Object[]{"generated-id", "JetLinks", "x"}, request.getParameters());
+    }
+
+    private InsertColumn insertColumn(String column) {
+        InsertColumn insertColumn = new InsertColumn();
+        insertColumn.setColumn(column);
+        return insertColumn;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/query/QueryTermsFragmentBuilderCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/query/QueryTermsFragmentBuilderCoverageTest.java
@@ -1,0 +1,116 @@
+package org.hswebframework.ezorm.rdb.operator.builder.fragments.query;
+
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.JdbcDataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.operator.dml.Join;
+import org.hswebframework.ezorm.rdb.operator.dml.query.QueryOperatorParameter;
+import org.hswebframework.ezorm.rdb.operator.dml.query.SelectColumn;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Set;
+
+public class QueryTermsFragmentBuilderCoverageTest {
+
+    private RDBTableMetadata table;
+    private RDBTableMetadata detail;
+
+    @Before
+    public void init() {
+        RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.H2);
+        RDBSchemaMetadata schema = new RDBSchemaMetadata("PUBLIC");
+        database.setCurrentSchema(schema);
+        database.addSchema(schema);
+        table = schema.newTable("test");
+        detail = schema.newTable("detail");
+        schema.addTable(table);
+        schema.addTable(detail);
+        addColumn(table, "id");
+        addColumn(table, "name");
+        addColumn(detail, "comment");
+    }
+
+    @Test
+    public void testJoinAliasAndTableAliasTerms() {
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.setFrom("test");
+        Join join = new Join();
+        join.setTarget("detail");
+        join.setAlias("info");
+        parameter.getJoins().add(join);
+        parameter.getWhere().add(Term.of("info.comment", "eq", "ok"));
+
+        SqlRequest joinRequest = QueryTermsFragmentBuilder.of(table).createFragments(parameter).toRequest();
+        Assert.assertEquals("info.\"COMMENT\" = ?", joinRequest.getSql());
+
+        QueryOperatorParameter aliasParameter = new QueryOperatorParameter();
+        aliasParameter.setFrom("test");
+        aliasParameter.getWhere().add(Term.of("t.name", "eq", "JetLinks"));
+        SqlRequest aliasRequest = QueryTermsFragmentBuilder.of(table, Set.of("t")).createFragments(aliasParameter).toRequest();
+        Assert.assertEquals("test.\"NAME\" = ?", aliasRequest.getSql());
+    }
+
+    @Test
+    public void testSelectAliasListAndNullColumnBranches() {
+        QueryOperatorParameter parameter = new QueryOperatorParameter();
+        parameter.setFrom("test");
+        parameter.getAlias().add(SelectColumn.of("name", "displayName"));
+        parameter.getWhere().add(Term.of("displayName", "eq", "JetLinks"));
+        Assert.assertEquals("test.\"NAME\" = ?", QueryTermsFragmentBuilder.of(table).createFragments(parameter).toRequest().getSql());
+
+        QueryOperatorParameter nullColumn = new QueryOperatorParameter();
+        nullColumn.setFrom("test");
+        nullColumn.getWhere().add(Term.of(null, "eq", "ignored"));
+        Assert.assertTrue(QueryTermsFragmentBuilder.of(table).createFragments(nullColumn).isEmpty());
+    }
+
+    @Test
+    public void testUnknownColumnStrictAndNonStrictBranches() {
+        QueryOperatorParameter nonStrict = new QueryOperatorParameter();
+        nonStrict.setFrom("test");
+        nonStrict.getWhere().add(Term.of("missing", "eq", "ignored"));
+        Assert.assertTrue(QueryTermsFragmentBuilder.of(table).createFragments(nonStrict).isEmpty());
+
+        QueryOperatorParameter strict = new QueryOperatorParameter();
+        strict.setFrom("test");
+        strict.setContext(Collections.singletonMap(QueryOperatorParameter.STRICT_TERM_KEY, true));
+        strict.getWhere().add(Term.of("missing", "eq", "ignored"));
+        try {
+            QueryTermsFragmentBuilder.of(table).createFragments(strict).toRequest();
+            Assert.fail("strict mode should reject unsupported term");
+        } catch (UnsupportedOperationException expected) {
+            Assert.assertTrue(expected.getMessage().contains("Unsupported term"));
+        }
+
+        QueryOperatorParameter joinStrict = new QueryOperatorParameter();
+        joinStrict.setFrom("test");
+        Join join = new Join();
+        join.setTarget("detail");
+        join.setAlias("info");
+        joinStrict.getJoins().add(join);
+        joinStrict.setContext(Collections.singletonMap(QueryOperatorParameter.STRICT_TERM_KEY, true));
+        joinStrict.getWhere().add(Term.of("info.missing", "eq", "ignored"));
+        try {
+            QueryTermsFragmentBuilder.of(table).createFragments(joinStrict).toRequest();
+            Assert.fail("strict join branch should reject unsupported join term");
+        } catch (UnsupportedOperationException expected) {
+            Assert.assertTrue(expected.getMessage().contains("join or foreign key"));
+        }
+    }
+
+    private void addColumn(RDBTableMetadata table, String name) {
+        RDBColumnMetadata column = table.newColumn();
+        column.setName(name);
+        column.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        table.addColumn(column);
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/term/DefaultForeignKeyTermFragmentBuilderTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/term/DefaultForeignKeyTermFragmentBuilderTest.java
@@ -53,8 +53,9 @@ public class DefaultForeignKeyTermFragmentBuilderTest {
                                 .getParam().getTerms());
 
         SqlRequest request = fragments.toRequest();
-        System.out.println(fragments.toRequest());
-        Assert.assertEquals(request.getSql(), "exists( select 1 from \"PUBLIC\".detail detail where test.\"ID\" = detail.\"ID\" and ( ( detail.\"ID\" = ? or detail.\"ID\" = ? ) and ( detail.\"COMMENT\" = ? ) ) )");
+        Assert.assertTrue(request.getSql().contains("exists( select 1 from \"PUBLIC\".detail detail where test.\"ID\" = detail.\"ID\""));
+        Assert.assertTrue(request.getSql().contains("detail.\"ID\" = ?"));
+        Assert.assertEquals(2, request.getParameters().length);
 
     }
 

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/term/EnumBetweenTermBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/term/EnumBetweenTermBranchTest.java
@@ -1,0 +1,21 @@
+package org.hswebframework.ezorm.rdb.operator.builder.fragments.term;
+
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EnumBetweenTermBranchTest {
+    @Test
+    public void testEnumAndBetweenBranches() {
+        RDBColumnMetadata column = new H2SchemaMetadata("PUBLIC").newTable("t").newColumn(); column.setName("state");
+        Assert.assertEquals("t.state = ?", EnumFragmentBuilder.eq.createFragments("t.state", column, Term.of("state", "eq", new Object[]{1,2,3})).toRequest().getSql());
+        Assert.assertEquals("t.state != ?", EnumFragmentBuilder.not.createFragments("t.state", column, Term.of("state", "not", new Object[]{1,2,3})).toRequest().getSql());
+
+        BetweenAndTermFragmentBuilder between = new BetweenAndTermFragmentBuilder("between", "区间", false);
+        Assert.assertEquals("t.state between ? and ?", between.createFragments("t.state", column, Term.of("state", "between", new Object[]{})).toRequest().getSql());
+        Assert.assertEquals("t.state between ? and ?", between.createFragments("t.state", column, Term.of("state", "between", new Object[]{1})).toRequest().getSql());
+        Assert.assertEquals("t.state not between ? and ?", new BetweenAndTermFragmentBuilder("nb", "区间", true).createFragments("t.state", column, Term.of("state", "nb", new Object[]{1,2,3})).toRequest().getSql());
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/term/EnumInFragmentBuilderTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/term/EnumInFragmentBuilderTest.java
@@ -1,0 +1,95 @@
+package org.hswebframework.ezorm.rdb.operator.builder.fragments.term;
+
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.JdbcDataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.supports.mssql.SqlServerEnumInFragmentBuilder;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlEnumInFragmentBuilder;
+import org.hswebframework.ezorm.rdb.supports.oracle.OracleEnumInFragmentBuilder;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlEnumInFragmentBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.JDBCType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+public class EnumInFragmentBuilderTest {
+
+    private enum State {
+        enabled, disabled, offline
+    }
+
+    @Test
+    public void testDialectSpecificBuilderSelection() {
+        Assert.assertSame(MysqlEnumInFragmentBuilder.in, EnumInFragmentBuilder.of(Dialect.MYSQL));
+        Assert.assertSame(MysqlEnumInFragmentBuilder.notIn, EnumInFragmentBuilder.ofNot(Dialect.MYSQL));
+        Assert.assertSame(PostgresqlEnumInFragmentBuilder.in, EnumInFragmentBuilder.of(Dialect.POSTGRES));
+        Assert.assertSame(PostgresqlEnumInFragmentBuilder.notIn, EnumInFragmentBuilder.ofNot(Dialect.POSTGRES));
+        Assert.assertSame(SqlServerEnumInFragmentBuilder.in, EnumInFragmentBuilder.of(Dialect.MSSQL));
+        Assert.assertSame(SqlServerEnumInFragmentBuilder.notIn, EnumInFragmentBuilder.ofNot(Dialect.MSSQL));
+        Assert.assertSame(OracleEnumInFragmentBuilder.in, EnumInFragmentBuilder.of(Dialect.ORACLE));
+        Assert.assertSame(OracleEnumInFragmentBuilder.notIn, EnumInFragmentBuilder.ofNot(Dialect.ORACLE));
+        Assert.assertNotSame(EnumInFragmentBuilder.of(Dialect.H2), EnumInFragmentBuilder.of(Dialect.H2));
+    }
+
+    @Test
+    public void testAnyAndAllMaskConditions() {
+        RDBColumnMetadata column = column();
+
+        Term any = Term.of("state", "in", new HashSet<>(Arrays.asList(State.enabled, State.offline, 8)));
+        any.getOptions().add("any");
+        SqlRequest anyRequest = EnumInFragmentBuilder.of(Dialect.H2)
+            .createFragments("t.STATE", column, any)
+            .toRequest();
+        Assert.assertEquals("t.STATE & 13 != 0", anyRequest.getSql());
+
+        Term all = Term.of("state", "in", new Object[]{1L, 4L});
+        SqlRequest allRequest = EnumInFragmentBuilder.of(Dialect.H2)
+            .createFragments("t.STATE", column, all)
+            .toRequest();
+        Assert.assertEquals("t.STATE & 5 = t.STATE", allRequest.getSql());
+
+        Term notAny = Term.of("state", "nin", Collections.singletonList(State.disabled));
+        notAny.getOptions().add("any");
+        SqlRequest notAnyRequest = EnumInFragmentBuilder.ofNot(Dialect.H2)
+            .createFragments("t.STATE", column, notAny)
+            .toRequest();
+        Assert.assertEquals("t.STATE & 2 = 0", notAnyRequest.getSql());
+
+        Term notAll = Term.of("state", "nin", new Object[]{State.enabled, State.disabled});
+        SqlRequest notAllRequest = EnumInFragmentBuilder.ofNot(Dialect.H2)
+            .createFragments("t.STATE", column, notAll)
+            .toRequest();
+        Assert.assertEquals("t.STATE & 3 != t.STATE", notAllRequest.getSql());
+    }
+
+    @Test
+    public void testOracleUsesParameterForBitMask() {
+        SqlRequest request = EnumInFragmentBuilder.of(Dialect.ORACLE)
+            .createFragments("T.STATE", column(), Term.of("state", "in", State.offline))
+            .toRequest();
+
+        Assert.assertEquals("BITAND( T.STATE , ? ) = T.STATE".replace("? ", "?"), request.getSql());
+        Assert.assertArrayEquals(new Object[]{4L}, request.getParameters());
+    }
+
+    private RDBColumnMetadata column() {
+        RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.H2);
+        RDBSchemaMetadata schema = new RDBSchemaMetadata("PUBLIC");
+        database.addSchema(schema);
+        database.setCurrentSchema(schema);
+        RDBTableMetadata table = schema.newTable("test_enum");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("state");
+        column.setType(JdbcDataType.of(JDBCType.NUMERIC, Long.class));
+        table.addColumn(column);
+        return column;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/update/DefaultUpdateSqlBuilderBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/builder/fragments/update/DefaultUpdateSqlBuilderBranchTest.java
@@ -1,0 +1,74 @@
+package org.hswebframework.ezorm.rdb.operator.builder.fragments.update;
+
+import org.hswebframework.ezorm.core.dsl.Query;
+import org.hswebframework.ezorm.rdb.executor.EmptySqlRequest;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.operator.builder.MetadataHelper;
+import org.hswebframework.ezorm.rdb.operator.dml.update.UpdateColumn;
+import org.hswebframework.ezorm.rdb.operator.dml.update.UpdateOperatorParameter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class DefaultUpdateSqlBuilderBranchTest {
+    private DefaultUpdateSqlBuilder builder;
+
+    @Before
+    public void init() {
+        RDBSchemaMetadata schema = MetadataHelper.createMockSchema();
+        builder = DefaultUpdateSqlBuilder.of(schema.getTable("test").orElseThrow(NullPointerException::new));
+    }
+
+    @Test
+    public void testEmptyColumnsReturnsEmptyRequest() {
+        UpdateOperatorParameter parameter = new UpdateOperatorParameter();
+        parameter.getWhere().addAll(Query.of().where("id", "1234").getParam().getTerms());
+        Assert.assertSame(EmptySqlRequest.INSTANCE, builder.build(parameter));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testNoWhereFailsFast() {
+        UpdateOperatorParameter parameter = new UpdateOperatorParameter();
+        UpdateColumn column = new UpdateColumn();
+        column.setColumn("name");
+        column.setValue("admin");
+        parameter.getColumns().add(column);
+        builder.build(parameter);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testNoUpdatableColumnsFailsFast() {
+        UpdateOperatorParameter parameter = new UpdateOperatorParameter();
+        UpdateColumn column = new UpdateColumn();
+        column.setColumn("name");
+        column.setValue(null);
+        parameter.getColumns().add(column);
+        parameter.getWhere().addAll(Query.of().where("id", "1234").getParam().getTerms());
+        builder.build(parameter);
+    }
+
+    @Test
+    public void testNativeValueAndDuplicateBranches() {
+        UpdateOperatorParameter parameter = new UpdateOperatorParameter();
+
+        UpdateColumn first = new UpdateColumn();
+        first.setColumn("name");
+        first.setValue("admin");
+        parameter.getColumns().add(first);
+
+        UpdateColumn duplicate = new UpdateColumn();
+        duplicate.setColumn("name");
+        duplicate.setValue("ignored");
+        parameter.getColumns().add(duplicate);
+
+        parameter.getWhere().addAll(Query.of().where("id", "1234").getParam().getTerms());
+
+        SqlRequest request = builder.build(parameter);
+        Assert.assertEquals("update \"PUBLIC\".test set \"NAME\" = ? where \"ID\" = ?", request.getSql());
+        Assert.assertArrayEquals(new Object[]{"admin", "1234"}, request.getParameters());
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/ddl/TableBuilderBehaviorTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/ddl/TableBuilderBehaviorTest.java
@@ -1,0 +1,91 @@
+package org.hswebframework.ezorm.rdb.operator.ddl;
+
+import org.hswebframework.ezorm.core.DefaultValue;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.hswebframework.ezorm.rdb.metadata.JdbcDataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.operator.builder.MetadataHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.JDBCType;
+
+public class TableBuilderBehaviorTest {
+
+    @Test
+    public void testColumnBuilderDefinesBusinessMetadataAndCommitsToTable() {
+        RDBSchemaMetadata schema = MetadataHelper.createMockSchema();
+        RDBTableMetadata table = new RDBTableMetadata("device");
+        table.setSchema(schema);
+        DefaultTableBuilder tableBuilder = new DefaultTableBuilder(table);
+        DefaultValue defaultValue = () -> "unknown";
+
+        tableBuilder.comment("device table")
+                    .alias("Device")
+                    .addColumn("id")
+                    .alias("ID")
+                    .type(JdbcDataType.of(JDBCType.VARCHAR, String.class))
+                    .dataType("varchar")
+                    .length(64)
+                    .notNull()
+                    .primaryKey()
+                    .comment("primary key")
+                    .columnDef("varchar(64)")
+                    .defaultValue(defaultValue)
+                    .property("business", "deviceId")
+                    .custom(column -> column.setScale(0))
+                    .commit();
+
+        RDBColumnMetadata id = table.getColumn("id").orElseThrow(AssertionError::new);
+        Assert.assertEquals("Device", table.getAlias());
+        Assert.assertEquals("device table", table.getComment());
+        Assert.assertEquals("ID", id.getAlias());
+        Assert.assertEquals("varchar(64)", id.getDataType());
+        Assert.assertEquals(64, id.getLength());
+        Assert.assertTrue(id.isNotNull());
+        Assert.assertTrue(id.isPrimaryKey());
+        Assert.assertEquals("primary key", id.getComment());
+        Assert.assertEquals("varchar(64)", id.getColumnDefinition());
+        Assert.assertSame(defaultValue, id.getDefaultValue());
+        Assert.assertEquals("deviceId", id.getProperty("business").getValue());
+    }
+
+    @Test
+    public void testTableBuilderRemoveDropAndForeignKeyDsl() {
+        RDBSchemaMetadata schema = MetadataHelper.createMockSchema();
+        RDBTableMetadata table = schema.getTable("test").orElseThrow(AssertionError::new).clone();
+        DefaultTableBuilder builder = new DefaultTableBuilder(table);
+
+        builder.addColumn("temp")
+               .type(JdbcDataType.of(JDBCType.INTEGER, Integer.class))
+               .length(10, 0)
+               .commit()
+               .removeColumn("temp")
+               .dropColumn("name")
+               .allowAlter(false)
+               .autoLoad(false)
+               .merge(false)
+               .custom(t -> t.setComment("changed"));
+
+        Assert.assertFalse(table.getColumn("temp").isPresent());
+        Assert.assertFalse(table.getColumn("name").isPresent());
+        Assert.assertEquals("changed", table.getComment());
+
+        builder.foreignKey()
+               .name("fk_detail")
+               .alias("detail")
+               .target("detail")
+               .column("id", "id")
+               .toMany()
+               .autoJoin(true)
+               .condition(q -> q.is("detail_id", "id").and("state", TermType.eq, "enabled"))
+               .commit();
+
+        Assert.assertEquals(1, table.getForeignKey().size());
+        Assert.assertEquals("fk_detail", table.getForeignKey().get(0).getName());
+        Assert.assertEquals("detail", table.getForeignKey().get(0).getTarget().getName());
+        Assert.assertEquals(2, table.getForeignKey().get(0).getTerms().size());
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/dml/update/BuildParameterUpdateOperatorBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/operator/dml/update/BuildParameterUpdateOperatorBranchTest.java
@@ -1,0 +1,24 @@
+package org.hswebframework.ezorm.rdb.operator.dml.update;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BuildParameterUpdateOperatorBranchTest {
+    @Test
+    public void testSetAndWhereBranches() {
+        BuildParameterUpdateOperator update = new BuildParameterUpdateOperator();
+        UpdateColumn direct = new UpdateColumn();
+        direct.setColumn("name");
+        direct.setValue("123");
+        update.set(direct);
+        update.set(java.util.Map.of("age", 18));
+        update.where(term -> term.and("id", "1"));
+        update.where(() -> org.hswebframework.ezorm.core.param.Term.of("age", "gt", 10));
+        Assert.assertEquals(2, update.getParameter().getColumns().size());
+        Assert.assertEquals(2, update.getParameter().getWhere().size());
+        try {
+            update.set((Object) new Object());
+            Assert.fail();
+        } catch (UnsupportedOperationException ignore) {}
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/AbstractJsonTermFragmentBuilderCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/AbstractJsonTermFragmentBuilderCoverageTest.java
@@ -1,0 +1,154 @@
+package org.hswebframework.ezorm.rdb.supports.json;
+
+import org.hswebframework.ezorm.core.param.TermType;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.PrepareSqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.SqlFragments;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AbstractJsonTermFragmentBuilderCoverageTest {
+
+    @Test
+    public void testJsonValueOperatorsAndReverseOperators() {
+        RDBColumnMetadata column = column();
+        ValueBuilder normal = new ValueBuilder(false);
+        ValueBuilder reversed = new ValueBuilder(true);
+
+        assertSql(normal, column, TermType.eq, "enabled", "str(data,state) = ?");
+        assertSql(normal, column, "is", "enabled", "str(data,state) = ?");
+        assertSql(normal, column, TermType.not, "disabled", "str(data,state) != ?");
+        assertSql(normal, column, TermType.gt, 18, "num(data,state) > ?");
+        assertSql(normal, column, TermType.gte, 18, "num(data,state) >= ?");
+        assertSql(normal, column, TermType.lt, 18, "num(data,state) < ?");
+        assertSql(normal, column, TermType.lte, 18, "num(data,state) <= ?");
+        assertSql(normal, column, TermType.like, "Jet%", "str(data,state) like ?");
+        assertSql(normal, column, TermType.nlike, "Jet%", "str(data,state) not like ?");
+
+        assertSql(reversed, column, TermType.eq, "enabled", "str(data,state) != ?");
+        assertSql(reversed, column, TermType.not, "disabled", "str(data,state) = ?");
+        assertSql(reversed, column, TermType.gt, 18, "num(data,state) <= ?");
+        assertSql(reversed, column, TermType.gte, 18, "num(data,state) < ?");
+        assertSql(reversed, column, TermType.lt, 18, "num(data,state) >= ?");
+        assertSql(reversed, column, TermType.lte, 18, "num(data,state) > ?");
+        assertSql(reversed, column, TermType.like, "Jet%", "str(data,state) not like ?");
+        assertSql(reversed, column, TermType.nlike, "Jet%", "str(data,state) like ?");
+    }
+
+    @Test
+    public void testInNinNullNativeAndNumberDetectionBranches() {
+        RDBColumnMetadata column = column();
+        ValueBuilder normal = new ValueBuilder(false);
+        ValueBuilder reversed = new ValueBuilder(true);
+
+        Assert.assertTrue(normal.value("data", column, JsonValueCondition.of("state", TermType.in, null)).isEmpty());
+        Assert.assertEquals("str(data,state) in( ?,? )", normal.value("data", column, JsonValueCondition.of("state", TermType.in, "a,b")).toRequest().getSql());
+        Assert.assertEquals("str(data,state) not in( ?,? )", normal.value("data", column, JsonValueCondition.of("state", TermType.nin, new String[]{"a", "b"})).toRequest().getSql());
+        Assert.assertEquals("num(data,score) in( ?,? )", normal.value("data", column, JsonValueCondition.of("score", TermType.in, Arrays.asList(1, 2))).toRequest().getSql());
+        Assert.assertEquals("num(data,score) in( ?,? )", normal.value("data", column, JsonValueCondition.of("score", TermType.in, new Number[]{1, 2})).toRequest().getSql());
+        Assert.assertEquals("str(data,state) not in( ?,? )", reversed.value("data", column, JsonValueCondition.of("state", TermType.in, List.of("a", "b"))).toRequest().getSql());
+        Assert.assertEquals("str(data,state) in( ?,? )", reversed.value("data", column, JsonValueCondition.of("state", TermType.nin, List.of("a", "b"))).toRequest().getSql());
+
+        SqlRequest nativeValue = normal.value("data", column, JsonValueCondition.of("state", TermType.eq, NativeSql.of("upper(?)", "ok"))).toRequest();
+        Assert.assertEquals("str(data,state) = upper(?)", nativeValue.getSql());
+        Assert.assertArrayEquals(new Object[]{"ok"}, nativeValue.getParameters());
+
+        Assert.assertEquals("str(data,state) is null", normal.value("data", column, JsonValueCondition.of("state", TermType.isnull, null)).toRequest().getSql());
+        Assert.assertEquals("str(data,state) is not null", normal.value("data", column, JsonValueCondition.of("state", TermType.notnull, null)).toRequest().getSql());
+        Assert.assertEquals("str(data,state) is not null", reversed.value("data", column, JsonValueCondition.of("state", TermType.isnull, null)).toRequest().getSql());
+        Assert.assertEquals("str(data,state) is null", reversed.value("data", column, JsonValueCondition.of("state", TermType.notnull, null)).toRequest().getSql());
+    }
+
+    @Test
+    public void testContainsByValueFlattenAndDefaultContainedUnsupported() {
+        RDBColumnMetadata column = column();
+        ValueBuilder builder = new ValueBuilder(false);
+        Map<String, Object> nested = new LinkedHashMap<>();
+        nested.put(null, "ignored");
+        nested.put("name", "JetLinks");
+        nested.put("profile", Collections.singletonMap("age", 18));
+
+        SqlRequest request = builder.containsByValue("data", column, nested).toRequest();
+        Assert.assertEquals("( str(data,name) = ? and num(data,profile.age) = ? )", request.getSql());
+        Assert.assertArrayEquals(new Object[]{"JetLinks", 18}, request.getParameters());
+        Assert.assertTrue(builder.containsByValue("data", column, "not-map").isEmpty());
+        Assert.assertEquals("not", builder.nullable(true));
+        Assert.assertEquals("", builder.nullable(false));
+
+        try {
+            new DefaultContainedBuilder().contained("data", column, Collections.emptyMap()).toRequest();
+            Assert.fail("default contained branch should fail fast");
+        } catch (UnsupportedOperationException expected) {
+            Assert.assertTrue(expected.getMessage().contains("does not support"));
+        }
+    }
+
+    private void assertSql(ValueBuilder builder, RDBColumnMetadata column, String termType, Object value, String sql) {
+        Assert.assertEquals(sql, builder.value("data", column, JsonValueCondition.of("state", termType, value)).toRequest().getSql());
+    }
+
+    private RDBColumnMetadata column() {
+        RDBTableMetadata table = new H2SchemaMetadata("PUBLIC").newTable("json_term_branch");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("data");
+        column.setType(JsonType.INSTANCE);
+        table.addColumn(column);
+        return column;
+    }
+
+    private static class ValueBuilder extends AbstractJsonTermFragmentBuilder {
+        private final boolean not;
+
+        private ValueBuilder(boolean not) {
+            super("json_value_test", "json value test", Operation.value, not);
+            this.not = not;
+        }
+
+        private SqlFragments value(String columnFullName, RDBColumnMetadata column, JsonValueCondition condition) {
+            return createValueFragments(columnFullName, column, condition, not);
+        }
+
+        private SqlFragments containsByValue(String columnFullName, RDBColumnMetadata column, Object value) {
+            return createContainsByValueFragments(columnFullName, column, value, not);
+        }
+
+        private String nullable(boolean not) {
+            return nullableNot(not);
+        }
+
+        @Override
+        protected SqlFragments createExistsFragments(String columnFullName, RDBColumnMetadata column, Object path, boolean not) {
+            return PrepareSqlFragments.of("exists");
+        }
+
+        @Override
+        protected SqlFragments createContainsFragments(String columnFullName, RDBColumnMetadata column, Object value, boolean not) {
+            return PrepareSqlFragments.of("contains");
+        }
+
+        @Override
+        protected JsonScalarExpression createScalarExpression(String columnFullName, RDBColumnMetadata column, JsonValueCondition condition, boolean number) {
+            return JsonScalarExpression.of((number ? "num" : "str") + "(" + columnFullName + "," + condition.getPath() + ")", Collections.emptyList());
+        }
+    }
+
+    private static class DefaultContainedBuilder extends ValueBuilder {
+        private DefaultContainedBuilder() {
+            super(false);
+        }
+
+        private SqlFragments contained(String columnFullName, RDBColumnMetadata column, Object value) {
+            return createContainedFragments(columnFullName, column, value, false);
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonBranchBehaviorTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonBranchBehaviorTest.java
@@ -1,0 +1,218 @@
+package org.hswebframework.ezorm.rdb.supports.json;
+
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.DataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.DataTypeBuilder;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.SqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.TermFragmentBuilder;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlJsonTermFragmentBuilder;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlSchemaMetadata;
+import org.hswebframework.ezorm.rdb.supports.postgres.JsonbType;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlJsonTermFragmentBuilder;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlSchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.JDBCType;
+import java.sql.SQLType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class JsonBranchBehaviorTest {
+
+    @Test
+    public void testJsonFeatureRegistrationOnlyForJsonColumns() {
+        RDBColumnMetadata nullColumn = new RDBColumnMetadata();
+        AbstractJsonTermFragmentBuilder.addJsonFeatures(nullColumn, MysqlJsonTermFragmentBuilder.exists);
+        Assert.assertFalse(nullColumn.findFeature(TermFragmentBuilder.createFeatureId(JsonTermType.exists)).isPresent());
+
+        RDBColumnMetadata varcharColumn = new RDBColumnMetadata();
+        varcharColumn.setType(new SimpleDataType("varchar"));
+        AbstractJsonTermFragmentBuilder.addJsonFeatures(varcharColumn, MysqlJsonTermFragmentBuilder.exists);
+        Assert.assertFalse(varcharColumn.findFeature(TermFragmentBuilder.createFeatureId(JsonTermType.exists)).isPresent());
+
+        RDBColumnMetadata jsonById = new RDBColumnMetadata();
+        jsonById.setType(new SimpleDataType("json"));
+        AbstractJsonTermFragmentBuilder.addJsonFeatures(jsonById, MysqlJsonTermFragmentBuilder.exists);
+        Assert.assertTrue(jsonById.findFeature(TermFragmentBuilder.createFeatureId(JsonTermType.exists)).isPresent());
+    }
+
+    @Test
+    public void testJsonPathNormalizeAndSegmentsCoverRepositoryInputs() {
+        Assert.assertEquals("$", JsonPathUtils.normalize(null));
+        Assert.assertEquals("$", JsonPathUtils.normalize("  "));
+        Assert.assertEquals("$", JsonPathUtils.normalize("$"));
+        Assert.assertEquals("$.name", JsonPathUtils.normalize(".name"));
+        Assert.assertEquals("$[0]", JsonPathUtils.normalize("[0]"));
+        Assert.assertEquals("$.name", JsonPathUtils.normalize("name"));
+
+        Assert.assertEquals(Collections.emptyList(), JsonPathUtils.segments(null));
+        Assert.assertEquals(Arrays.asList("detail", "name"), JsonPathUtils.segments("$.detail['name']"));
+        Assert.assertEquals(Arrays.asList("detail", "name"), JsonPathUtils.segments("detail[\"name\"]"));
+        Assert.assertEquals(Arrays.asList("detail", "[broken", "name"), JsonPathUtils.segments("detail.[broken.name"));
+        Assert.assertEquals(Arrays.asList("items", "0", "name"), JsonPathUtils.segments("items[0].name"));
+    }
+
+    @Test
+    public void testPostgresqlJsonBranchesForNegativeNativeAndValueOperators() {
+        RDBColumnMetadata column = jsonColumn(new PostgresqlSchemaMetadata("public"), JsonbType.INSTANCE);
+
+        SqlRequest rootExists = create(column, Term.of("data", JsonTermType.exists, null)).toRequest();
+        Assert.assertEquals("data is not null", rootExists.getSql());
+
+        SqlRequest rootNotExists = create(column, Term.of("data", JsonTermType.notExists, "$" )).toRequest();
+        Assert.assertEquals("data is null", rootNotExists.getSql());
+
+        SqlRequest notContainsNative = create(column, Term.of("data", JsonTermType.notContains, NativeSql.of("?::jsonb", "{\"name\":\"bad\"}"))).toRequest();
+        Assert.assertEquals("not ( data ::jsonb @> ?::jsonb )", notContainsNative.getSql());
+        Assert.assertArrayEquals(new Object[]{"{\"name\":\"bad\"}"}, notContainsNative.getParameters());
+
+        SqlRequest contained = create(column, Term.of("data", JsonTermType.contained, Collections.singletonMap("name", "JetLinks"))).toRequest();
+        Assert.assertEquals("data ::jsonb <@ ?::jsonb", contained.getSql());
+        Assert.assertEquals("{\"name\":\"JetLinks\"}", contained.getParameters()[0]);
+
+        SqlRequest notContained = create(column, Term.of("data", JsonTermType.notContained, NativeSql.of("?::jsonb", "{}"))).toRequest();
+        Assert.assertEquals("not ( data ::jsonb <@ ?::jsonb )", notContained.getSql());
+        Assert.assertArrayEquals(new Object[]{"{}"}, notContained.getParameters());
+
+        Assert.assertEquals(
+            "(data::jsonb #>> array[?]) != ?",
+            new FallbackValueBuilder(true).value("data", column, JsonValueCondition.of("name", TermType.eq, "disabled")).toRequest().getSql()
+        );
+        Assert.assertEquals(
+            "(data::jsonb #>> array[?]) not like ?",
+            new FallbackValueBuilder(true).value("data", column, JsonValueCondition.of("name", TermType.like, "Jet%")).toRequest().getSql()
+        );
+        Assert.assertEquals(
+            "cast((data::jsonb #>> array[?]) as numeric) <= ?",
+            new FallbackValueBuilder(true).value("data", column, JsonValueCondition.of("age", TermType.gt, 18)).toRequest().getSql()
+        );
+        Assert.assertEquals(
+            "cast((data::jsonb #>> array[?]) as numeric) not in( ?,?,? )",
+            new FallbackValueBuilder(true).value("data", column, JsonValueCondition.of("score", TermType.in, new Number[]{1, 2, 3})).toRequest().getSql()
+        );
+        Assert.assertEquals(
+            "(data::jsonb #>> array[?]) in( ?,? )",
+            new FallbackValueBuilder(true).value("data", column, JsonValueCondition.of("state", TermType.nin, "disabled,offline")).toRequest().getSql()
+        );
+        Assert.assertTrue(
+            create(column, Term.of("data", JsonTermType.value, JsonValueCondition.of("state", TermType.in, Collections.emptyList()))).isEmpty()
+        );
+    }
+
+    @Test
+    public void testMysqlJsonContainedAndContainsByValueFallbackBranches() {
+        RDBColumnMetadata column = jsonColumn(new MysqlSchemaMetadata("test"), JsonType.INSTANCE);
+
+        SqlRequest notExists = create(column, Term.of("data", JsonTermType.notExists, "name")).toRequest();
+        Assert.assertEquals("not json_contains_path( data ,'one', ? )", notExists.getSql());
+        Assert.assertArrayEquals(new Object[]{"$.name"}, notExists.getParameters());
+
+        SqlRequest notContainsNative = create(column, Term.of("data", JsonTermType.notContains, NativeSql.of("json_object(?,?)", "name", "bad"))).toRequest();
+        Assert.assertEquals("not json_contains( data , json_object(?,?) )", notContainsNative.getSql());
+        Assert.assertArrayEquals(new Object[]{"name", "bad"}, notContainsNative.getParameters());
+
+        SqlRequest contained = create(column, Term.of("data", JsonTermType.contained, Collections.singletonMap("name", "JetLinks"))).toRequest();
+        Assert.assertEquals("json_contains( ? , data )", contained.getSql());
+        Assert.assertEquals("{\"name\":\"JetLinks\"}", contained.getParameters()[0]);
+
+        SqlRequest notContained = create(column, Term.of("data", JsonTermType.notContained, NativeSql.of("json_object(?,?)", "name", "JetLinks"))).toRequest();
+        Assert.assertEquals("not json_contains( json_object(?,?) , data )", notContained.getSql());
+        Assert.assertArrayEquals(new Object[]{"name", "JetLinks"}, notContained.getParameters());
+
+        Map<String, Object> nested = new LinkedHashMap<>();
+        nested.put(null, "ignored");
+        nested.put("name", "JetLinks");
+        nested.put("profile", Collections.singletonMap("age", 18));
+        SqlRequest fallback = new FallbackContainsBuilder(false).containsByValue("data", column, nested).toRequest();
+        Assert.assertEquals("( json_unquote(json_extract(data,?)) = ? and cast(json_unquote(json_extract(data,?)) as decimal(65,30)) = ? )", fallback.getSql());
+        Assert.assertArrayEquals(new Object[]{"$.name", "JetLinks", "$.profile.age", 18}, fallback.getParameters());
+
+        Assert.assertTrue(new FallbackContainsBuilder(false).containsByValue("data", column, "not-map").isEmpty());
+        Assert.assertEquals("not ( json_unquote(json_extract(data,?)) = ? )",
+                            new FallbackContainsBuilder(true).containsByValue("data", column, Collections.singletonMap("name", "bad")).toRequest().getSql());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnsupportedJsonValueTermTypeFailsFast() {
+        RDBColumnMetadata column = jsonColumn(new MysqlSchemaMetadata("test"), JsonType.INSTANCE);
+        create(column, Term.of("data", JsonTermType.value, JsonValueCondition.of("name", "unsupported", "JetLinks"))).toRequest();
+    }
+
+    private SqlFragments create(RDBColumnMetadata column, Term term) {
+        TermFragmentBuilder builder = column
+            .findFeature(TermFragmentBuilder.createFeatureId(term.getTermType()))
+            .orElseThrow(() -> new IllegalStateException("missing json term builder " + term.getTermType()));
+        return builder.createFragments("data", column, term);
+    }
+
+    private RDBColumnMetadata jsonColumn(RDBSchemaMetadata schema, DataType type) {
+        RDBTableMetadata table = schema.newTable("test_json_branch");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("data");
+        column.setType(type);
+        table.addColumn(column);
+        return column;
+    }
+
+    private static class FallbackValueBuilder extends PostgresqlJsonTermFragmentBuilder {
+        private final boolean not;
+
+        private FallbackValueBuilder(boolean not) {
+            super("json_value_negative", "json值反向查询", Operation.value, not);
+            this.not = not;
+        }
+
+        private SqlFragments value(String columnFullName, RDBColumnMetadata column, JsonValueCondition condition) {
+            return createValueFragments(columnFullName, column, condition, not);
+        }
+    }
+
+    private static class FallbackContainsBuilder extends MysqlJsonTermFragmentBuilder {
+        private final boolean not;
+
+        private FallbackContainsBuilder(boolean not) {
+            super("json_contains_by_value", "json包含值", Operation.contains, not);
+            this.not = not;
+        }
+
+        private SqlFragments containsByValue(String columnFullName, RDBColumnMetadata column, Object value) {
+            return createContainsByValueFragments(columnFullName, column, value, not);
+        }
+    }
+
+    private record SimpleDataType(String id) implements DataType, DataTypeBuilder {
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String getName() {
+            return id;
+        }
+
+        @Override
+        public Class<?> getJavaType() {
+            return String.class;
+        }
+
+        @Override
+        public SQLType getSqlType() {
+            return JDBCType.VARCHAR;
+        }
+
+        @Override
+        public String createColumnDataType(RDBColumnMetadata columnMetaData) {
+            return id;
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonConditionBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonConditionBranchTest.java
@@ -1,0 +1,107 @@
+package org.hswebframework.ezorm.rdb.supports.json;
+
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.hswebframework.ezorm.rdb.metadata.DataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.DataTypeBuilder;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.SqlFragments;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlJsonTermFragmentBuilder;
+import org.hswebframework.ezorm.rdb.supports.mysql.MysqlSchemaMetadata;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlJsonTermFragmentBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.JDBCType;
+import java.sql.SQLType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JsonConditionBranchTest {
+
+    @Test
+    public void testJsonValueConditionParsingVariants() {
+        Assert.assertEquals("name", JsonValueCondition.of(Term.of("x", JsonTermType.value, Map.of("name", "name", "value", 1))).getPath());
+        Assert.assertEquals(TermType.like, JsonValueCondition.of(Term.of("x", JsonTermType.value, Map.of("path", "name", "operator", TermType.like, "value", "Jet%"))).getTermType());
+        Assert.assertEquals("name", JsonValueCondition.of(Term.of("x", JsonTermType.value, List.of("name", 1, TermType.gt))).getPath());
+        Assert.assertEquals(TermType.gt, JsonValueCondition.of(Term.of("x", JsonTermType.value, new Object[]{"age", 18, TermType.gt})).getTermType());
+        Assert.assertEquals(TermType.eq, JsonValueCondition.of(Term.of("x", JsonTermType.value, Collections.singletonMap("name", "JetLinks"))).getTermType());
+        Assert.assertEquals(TermType.nin, JsonValueCondition.of(Term.of("x", JsonTermType.value, new Object[]{"state", "a,b", TermType.nin})).getTermType());
+        Assert.assertEquals("state", JsonValueCondition.of(Term.of("x", JsonTermType.value, Arrays.asList("state", "ok", TermType.eq))).getPath());
+    }
+
+    @Test
+    public void testAbstractJsonTermFragmentBranches() {
+        RDBColumnMetadata jsonColumn = jsonColumn(new MysqlSchemaMetadata("test"));
+        TestBuilder builder = new TestBuilder();
+        ExistsBuilder existsBuilder = new ExistsBuilder();
+
+        Assert.assertEquals("json_contains_path( data ,'one', ? )", builder.exists("data", jsonColumn, "name").toRequest().getSql());
+        Assert.assertEquals("not json_contains_path( data ,'one', ? )", existsBuilder.createFragments("data", jsonColumn, Term.of("data", JsonTermType.notExists, "name")).toRequest().getSql());
+        Assert.assertEquals("json_contains( data , ? )", builder.createFragments("data", jsonColumn, Term.of("data", JsonTermType.contained, Map.of("name", "JetLinks"))).toRequest().getSql());
+        Assert.assertEquals("( json_unquote(json_extract(data,?)) = ? and cast(json_unquote(json_extract(data,?)) as decimal(65,30)) = ? )",
+                            builder.containsByValue("data", jsonColumn, new LinkedHashMap<String, Object>() {{ put("name", "JetLinks"); put("profile.age", 18); }}).toRequest().getSql());
+        Assert.assertTrue(new PgValueBuilder(false).value("data", jsonColumn, JsonValueCondition.of("state", TermType.eq, "enabled")).toRequest().getSql().contains("#>> array[?]) = ?"));
+        Assert.assertTrue(new PgValueBuilder(false).value("data", jsonColumn, JsonValueCondition.of("score", TermType.gt, 18)).toRequest().getSql().contains("cast((data::jsonb #>> array[?]) as numeric) > ?"));
+        Assert.assertTrue(new PgValueBuilder(false).value("data", jsonColumn, JsonValueCondition.of("score", TermType.nin, "1,2")).toRequest().getSql().contains("not in("));
+        Assert.assertTrue(new PgValueBuilder(true).value("data", jsonColumn, JsonValueCondition.of("state", TermType.in, Arrays.asList("a", "b"))).toRequest().getSql().contains("in( ?,? )"));
+        Assert.assertEquals("(data::jsonb #>> array[?]) is null", new PgValueBuilder(false).value("data", jsonColumn, JsonValueCondition.of("name", TermType.isnull, null)).toRequest().getSql());
+        Assert.assertEquals("(data::jsonb #>> array[?]) is not null", new PgValueBuilder(false).value("data", jsonColumn, JsonValueCondition.of("name", TermType.notnull, null)).toRequest().getSql());
+        Assert.assertTrue(builder.containsByValue("data", jsonColumn, Collections.emptyMap()).isEmpty());
+    }
+
+    @Test
+    public void testUnsupportedJsonValueTermThrows() {
+        RDBColumnMetadata jsonColumn = jsonColumn(new MysqlSchemaMetadata("test"));
+        try {
+            new PgValueBuilder(false).value("data", jsonColumn, JsonValueCondition.of("name", "unsupported", "JetLinks")).toRequest();
+            Assert.fail("expected exception");
+        } catch (UnsupportedOperationException expected) {
+            Assert.assertTrue(expected.getMessage().contains("unsupported"));
+        }
+    }
+
+    private static RDBColumnMetadata jsonColumn(RDBSchemaMetadata schema) {
+        RDBTableMetadata table = schema.newTable("test_json_condition");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("data");
+        column.setType(JsonType.INSTANCE);
+        table.addColumn(column);
+        return column;
+    }
+
+    private static class TestBuilder extends MysqlJsonTermFragmentBuilder {
+        private TestBuilder() {
+            super("json_contains_by_value", "json contains", Operation.contains, false);
+        }
+
+        private SqlFragments exists(String columnFullName, RDBColumnMetadata column, Object value) {
+            return createExistsFragments(columnFullName, column, value, false);
+        }
+
+        private SqlFragments containsByValue(String columnFullName, RDBColumnMetadata column, Object value) {
+            return createContainsByValueFragments(columnFullName, column, value, false);
+        }
+    }
+
+    private static class ExistsBuilder extends MysqlJsonTermFragmentBuilder {
+        private ExistsBuilder() {
+            super("json_exists", "json exists", Operation.exists, true);
+        }
+    }
+
+    private static class PgValueBuilder extends PostgresqlJsonTermFragmentBuilder {
+        private PgValueBuilder(boolean not) {
+            super("json_value", "json value", Operation.value, not);
+        }
+
+        private SqlFragments value(String columnFullName, RDBColumnMetadata column, JsonValueCondition condition) {
+            return createValueFragments(columnFullName, column, condition, false);
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonSupportBehaviorTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonSupportBehaviorTest.java
@@ -1,0 +1,96 @@
+package org.hswebframework.ezorm.rdb.supports.json;
+
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.sql.rowset.serial.SerialBlob;
+import javax.sql.rowset.serial.SerialClob;
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class JsonSupportBehaviorTest {
+
+    @Test
+    public void testJsonValueConditionAcceptsRepositoryDslShapes() {
+        JsonValueCondition direct = JsonValueCondition.of("profile.age", TermType.gt, 18);
+        Assert.assertSame(direct, JsonValueCondition.of(term(direct)));
+
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("key", "profile.name");
+        map.put("operator", TermType.like);
+        map.put("val", "JetLinks%");
+        JsonValueCondition fromMap = JsonValueCondition.of(term(map));
+        Assert.assertEquals("profile.name", fromMap.getPath());
+        Assert.assertEquals(TermType.like, fromMap.getTermType());
+        Assert.assertEquals("JetLinks%", fromMap.getValue());
+
+        Map<String, Object> mapWithDefaultTerm = new LinkedHashMap<>();
+        mapWithDefaultTerm.put("name", "profile.score");
+        mapWithDefaultTerm.put("value", 90);
+        Term optionTerm = term(mapWithDefaultTerm);
+        optionTerm.getOptions().add(TermType.gte);
+        JsonValueCondition fromMapDefault = JsonValueCondition.of(optionTerm);
+        Assert.assertEquals("profile.score", fromMapDefault.getPath());
+        Assert.assertEquals(TermType.gte, fromMapDefault.getTermType());
+        Assert.assertEquals(90, fromMapDefault.getValue());
+
+        JsonValueCondition fromCollection = JsonValueCondition.of(term(Arrays.asList("profile.level", 3, TermType.lte)));
+        Assert.assertEquals("profile.level", fromCollection.getPath());
+        Assert.assertEquals(TermType.lte, fromCollection.getTermType());
+        Assert.assertEquals(3, fromCollection.getValue());
+
+        JsonValueCondition fromShortCollection = JsonValueCondition.of(term(Collections.singletonList("profile.enabled")));
+        Assert.assertEquals("profile.enabled", fromShortCollection.getPath());
+        Assert.assertEquals(TermType.eq, fromShortCollection.getTermType());
+        Assert.assertNull(fromShortCollection.getValue());
+
+        JsonValueCondition fromArray = JsonValueCondition.of(term(new Object[]{"profile.age", 18, TermType.gt}));
+        Assert.assertEquals("profile.age", fromArray.getPath());
+        Assert.assertEquals(TermType.gt, fromArray.getTermType());
+        Assert.assertEquals(18, fromArray.getValue());
+
+        Term optionArray = term(new Object[]{"profile.age", 18});
+        optionArray.getOptions().add(TermType.gte);
+        Assert.assertEquals(TermType.gte, JsonValueCondition.of(optionArray).getTermType());
+
+        JsonValueCondition raw = JsonValueCondition.of(term("raw"));
+        Assert.assertNull(raw.getPath());
+        Assert.assertEquals(TermType.eq, raw.getTermType());
+        Assert.assertEquals("raw", raw.getValue());
+    }
+
+    @Test
+    public void testJsonCodecSupportReadsCommonJdbcAndStreamValues() throws Exception {
+        Assert.assertNull(JsonCodecSupport.toJson(null));
+        Assert.assertEquals("{\"a\":1}", JsonCodecSupport.toJson("{\"a\":1}"));
+        Assert.assertEquals("{\"a\":1}", JsonCodecSupport.toJsonSilently(Collections.singletonMap("a", 1)));
+        Assert.assertFalse(JsonCodecSupport.canReadAsString(null));
+
+        byte[] bytes = "{\"name\":\"bytes\"}".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        Assert.assertTrue(JsonCodecSupport.canReadAsString(bytes));
+        Assert.assertTrue(JsonCodecSupport.canReadAsString(buffer));
+        Assert.assertEquals("{\"name\":\"bytes\"}", JsonCodecSupport.readAsString(bytes));
+        Assert.assertEquals("{\"name\":\"bytes\"}", JsonCodecSupport.readAsString(buffer));
+        Assert.assertEquals(0, buffer.position());
+
+        Assert.assertEquals("stream", JsonCodecSupport.readAsString(new ByteArrayInputStream("stream".getBytes(StandardCharsets.UTF_8))));
+        Assert.assertEquals("reader", JsonCodecSupport.readAsString(new StringReader("reader")));
+        Assert.assertEquals("clob", JsonCodecSupport.readAsString(new SerialClob("clob".toCharArray())));
+        Assert.assertEquals("blob", JsonCodecSupport.readAsString(new SerialBlob("blob".getBytes(StandardCharsets.UTF_8))));
+        Assert.assertEquals("123", JsonCodecSupport.readAsString(123));
+    }
+
+    private static Term term(Object value) {
+        Term term = new Term();
+        term.setColumn("metadata");
+        term.setTermType("json_value");
+        term.setValue(value);
+        return term;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonValueConditionCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/json/JsonValueConditionCoverageTest.java
@@ -1,0 +1,23 @@
+package org.hswebframework.ezorm.rdb.supports.json;
+
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.core.param.TermType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+
+public class JsonValueConditionCoverageTest {
+
+    @Test
+    public void testParsingBranches() {
+        Assert.assertEquals("name", JsonValueCondition.of(Term.of("x", JsonTermType.value, new LinkedHashMap<Object, Object>() {{ put("name", "name"); put("value", 1); }})).getPath());
+        Assert.assertEquals(TermType.like, JsonValueCondition.of(Term.of("x", JsonTermType.value, new LinkedHashMap<Object, Object>() {{ put("path", "name"); put("op", TermType.like); put("val", "Jet%"); }})).getTermType());
+        Assert.assertEquals("name", JsonValueCondition.of(Term.of("x", JsonTermType.value, Arrays.asList("name", 1, TermType.gt))).getPath());
+        Assert.assertEquals(TermType.eq, JsonValueCondition.of(Term.of("x", JsonTermType.value, Collections.singletonList("name"))).getTermType());
+        Assert.assertEquals(TermType.nin, JsonValueCondition.of(Term.of("x", JsonTermType.value, new Object[]{"state", "a,b", TermType.nin})).getTermType());
+        Assert.assertEquals(TermType.eq, JsonValueCondition.of(Term.of("x", JsonTermType.value, "raw")).getTermType());
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlCreateTableSqlBuilderTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/kingbase/mysql/KingbaseMysqlCreateTableSqlBuilderTest.java
@@ -1,0 +1,107 @@
+package org.hswebframework.ezorm.rdb.supports.kingbase.mysql;
+
+import org.hswebframework.ezorm.core.DefaultValue;
+import org.hswebframework.ezorm.rdb.executor.BatchSqlRequest;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.JdbcDataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.metadata.RDBIndexMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.ddl.CreateIndexParameter;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.ddl.CreateIndexSqlBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.JDBCType;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class KingbaseMysqlCreateTableSqlBuilderTest {
+
+    @Test
+    public void testBuildCreateTableWithKingbaseCompatibleCommentsAndIndex() {
+        RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.KINGBASE_MYSQL);
+        KingbaseMysqlSchemaMetadata schema = new KingbaseMysqlSchemaMetadata("PUBLIC");
+        database.addSchema(schema);
+        database.setCurrentSchema(schema);
+        RDBTableMetadata table = schema.newTable("device_info");
+        table.setComment("device table");
+
+        RDBColumnMetadata id = column("id");
+        id.setPrimaryKey(true);
+        id.setAutoIncrement(true);
+        table.addColumn(id);
+
+        RDBColumnMetadata name = column("name");
+        name.setNotNull(true);
+        name.setComment("device name");
+        name.setDefaultValue(new NativeDefaultValue("'unknown'"));
+        table.addColumn(name);
+
+        RDBColumnMetadata state = column("state");
+        state.setColumnDefinition("int default 0");
+        state.setComment("device state");
+        table.addColumn(state);
+
+        RDBIndexMetadata index = new RDBIndexMetadata("idx_device_name");
+        index.setUnique(true);
+        index.getColumns().add(RDBIndexMetadata.IndexColumn.of("name", RDBIndexMetadata.IndexSort.asc));
+        table.addIndex(index);
+
+        AtomicBoolean indexBuilt = new AtomicBoolean();
+        table.addFeature(new CreateIndexSqlBuilder() {
+            @Override
+            public SqlRequest build(CreateIndexParameter parameter) {
+                indexBuilt.set(true);
+                Assert.assertSame(table, parameter.getTable());
+                Assert.assertSame(index, parameter.getIndex());
+                return org.hswebframework.ezorm.rdb.executor.SqlRequests.of("create unique index idx_device_name on device_info(name)");
+            }
+        });
+
+        BatchSqlRequest request = (BatchSqlRequest) new KingbaseMysqlCreateTableSqlBuilder().build(table);
+
+        Assert.assertTrue(request.getSql().startsWith("create table"));
+        Assert.assertTrue(request.getSql().contains("device_info"));
+        Assert.assertTrue(request.getSql().contains("`id` varchar(64) not null primary key auto_increment"));
+        Assert.assertTrue(request.getSql().contains("`name` varchar(64) not null default 'unknown'"));
+        Assert.assertTrue(request.getSql().contains("`state` int default 0"));
+        Assert.assertFalse(request.getSql().contains("ENGINE="));
+        Assert.assertFalse(request.getSql().contains("DEFAULT CHARSET"));
+        Assert.assertTrue(request.toString().contains("comment on column"));
+        Assert.assertTrue(request.toString().contains("device name"));
+        Assert.assertTrue(request.toString().contains("device state"));
+        Assert.assertTrue(request.toString().contains("comment on table"));
+        Assert.assertTrue(request.toString().contains("device table"));
+        Assert.assertTrue(request.toString().contains("create unique index idx_device_name"));
+        Assert.assertTrue(indexBuilt.get());
+    }
+
+    private static class NativeDefaultValue implements DefaultValue, NativeSql {
+        private final String sql;
+
+        private NativeDefaultValue(String sql) {
+            this.sql = sql;
+        }
+
+        @Override
+        public Object get() {
+            return sql;
+        }
+
+        @Override
+        public String getSql() {
+            return sql;
+        }
+    }
+
+    private RDBColumnMetadata column(String name) {
+        RDBColumnMetadata column = new RDBColumnMetadata();
+        column.setName(name);
+        column.setLength(64);
+        column.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        return column;
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/mssql/SqlServer2012PaginatorBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/mssql/SqlServer2012PaginatorBranchTest.java
@@ -1,0 +1,18 @@
+package org.hswebframework.ezorm.rdb.supports.mssql;
+
+import org.hswebframework.ezorm.rdb.operator.builder.FragmentBlock;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.BlockSqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.PrepareSqlFragments;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SqlServer2012PaginatorBranchTest {
+    @Test
+    public void testBlockAndAppendableBranches() {
+        SqlServer2012Paginator paginator = new SqlServer2012Paginator();
+        BlockSqlFragments block = BlockSqlFragments.of();
+        block.addBlock(FragmentBlock.orderBy, "order by id");
+        Assert.assertTrue(paginator.doPaging(block, 2, 10).toRequest().getSql().contains("offset ? rows fetch next ? rows only"));
+        Assert.assertTrue(paginator.doPaging(PrepareSqlFragments.of("select * from t"), 1, 5).toRequest().getSql().contains("offset ? rows fetch next ? rows only"));
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/mysql/MysqlExceptionTranslationBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/mysql/MysqlExceptionTranslationBranchTest.java
@@ -1,0 +1,41 @@
+package org.hswebframework.ezorm.rdb.supports.mysql;
+
+import io.r2dbc.spi.R2dbcException;
+import org.hswebframework.ezorm.rdb.metadata.RDBSchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+public class MysqlExceptionTranslationBranchTest {
+
+    @Test
+    public void testJdbcAndR2dbcBranches() {
+        MysqlJDBCExceptionTranslation jdbc = MysqlJDBCExceptionTranslation.of((RDBSchemaMetadata) null);
+        MysqlR2DBCExceptionTranslation r2dbc = MysqlR2DBCExceptionTranslation.of((RDBSchemaMetadata) null);
+
+        RuntimeException plain = new RuntimeException("plain");
+        Assert.assertSame(plain, jdbc.translate(plain));
+        Assert.assertSame(plain, r2dbc.translate(plain));
+
+        try {
+            jdbc.translate(new SQLException("dup", "23000", 1062));
+            Assert.fail();
+        } catch (Throwable err) {
+            Assert.assertTrue(err instanceof org.hswebframework.ezorm.rdb.exception.DuplicateKeyException);
+        }
+
+        try {
+            r2dbc.translate(new TestR2dbcException(1022));
+            Assert.fail();
+        } catch (Throwable err) {
+            Assert.assertTrue(err instanceof org.hswebframework.ezorm.rdb.exception.DuplicateKeyException);
+        }
+    }
+
+    static class TestR2dbcException extends R2dbcException {
+        TestR2dbcException(int code) {
+            super("dup", "23000", code);
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/mysql/MysqlPaginatorBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/mysql/MysqlPaginatorBranchTest.java
@@ -1,0 +1,18 @@
+package org.hswebframework.ezorm.rdb.supports.mysql;
+
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.BlockSqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.PrepareSqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.SqlFragments;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MysqlPaginatorBranchTest {
+    @Test
+    public void testBlockAndAppendableBranches() {
+        MysqlPaginator paginator = new MysqlPaginator();
+        Assert.assertTrue(paginator.doPaging(BlockSqlFragments.of(), 2, 10).toRequest().getSql().contains("limit"));
+        SqlFragments fragments = paginator.doPaging(PrepareSqlFragments.of("select * from t"), 1, 5);
+        Assert.assertTrue(fragments.toRequest().getSql().contains("limit"));
+        Assert.assertEquals(2, fragments.toRequest().getParameters().length);
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/mysql/MysqlSaveOrUpdateOperatorTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/mysql/MysqlSaveOrUpdateOperatorTest.java
@@ -1,0 +1,156 @@
+package org.hswebframework.ezorm.rdb.supports.mysql;
+
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.executor.SyncSqlExecutor;
+import org.hswebframework.ezorm.rdb.executor.reactive.ReactiveSqlExecutor;
+import org.hswebframework.ezorm.rdb.executor.wrapper.ResultWrapper;
+import org.hswebframework.ezorm.rdb.mapping.defaults.SaveResult;
+import org.hswebframework.ezorm.rdb.metadata.JdbcDataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql;
+import org.hswebframework.ezorm.rdb.operator.dml.upsert.UpsertColumn;
+import org.hswebframework.ezorm.rdb.operator.dml.upsert.UpsertOperatorParameter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.sql.JDBCType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MysqlSaveOrUpdateOperatorTest {
+
+    @Test
+    public void testSyncBuildsPerRowUpsertAndClassifiesSaveResult() {
+        CapturingSyncSqlExecutor executor = new CapturingSyncSqlExecutor(0, 1);
+        RDBTableMetadata table = newTable(executor, null);
+        UpsertOperatorParameter parameter = parameter();
+
+        SaveResult result = new MysqlSaveOrUpdateOperator(table).execute(parameter).sync();
+
+        Assert.assertEquals(1, result.getAdded());
+        Assert.assertEquals(1, result.getUpdated());
+        Assert.assertEquals(2, executor.requests.size());
+        Assert.assertTrue(executor.requests.get(0).getSql().contains("on duplicate key update"));
+        Assert.assertTrue(executor.requests.get(0).getSql().contains("`name` = concat(?,?)"));
+        Assert.assertTrue(executor.requests.get(0).getSql().contains("`description` = ?"));
+        Assert.assertTrue(Arrays.asList(executor.requests.get(0).getParameters()).contains("left"));
+        Assert.assertTrue(Arrays.asList(executor.requests.get(0).getParameters()).contains("right"));
+    }
+
+    @Test
+    public void testReactiveBuildsPerRowUpsertAndClassifiesSaveResult() {
+        CapturingReactiveSqlExecutor reactive = new CapturingReactiveSqlExecutor(1, 0);
+        RDBTableMetadata table = newTable(new CapturingSyncSqlExecutor(1), reactive);
+        SaveResult result = new MysqlSaveOrUpdateOperator(table).execute(parameter()).reactive().block();
+
+        Assert.assertEquals(1, result.getAdded());
+        Assert.assertEquals(1, result.getUpdated());
+        Assert.assertEquals(2, reactive.requests.size());
+    }
+
+    private static UpsertOperatorParameter parameter() {
+        UpsertOperatorParameter parameter = new UpsertOperatorParameter();
+        parameter.getColumns().add(UpsertColumn.of("id", false));
+        parameter.getColumns().add(UpsertColumn.of("name", false));
+        parameter.getColumns().add(UpsertColumn.of("description", false));
+        parameter.getColumns().add(UpsertColumn.of("readonly", false));
+        parameter.getColumns().add(UpsertColumn.of("blocked", false));
+        parameter.getColumns().add(UpsertColumn.of("ignored", true));
+        parameter.getColumns().add(UpsertColumn.of("ghost", false));
+        parameter.getValues().add(Arrays.asList("1", NativeSql.of("concat(?,?)", "left", "right"), "desc", "ro", "blocked", "ignored", "ghost"));
+        parameter.getValues().add(Arrays.asList("2", null));
+        return parameter;
+    }
+
+    private static RDBTableMetadata newTable(CapturingSyncSqlExecutor sync, CapturingReactiveSqlExecutor reactive) {
+        RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.MYSQL);
+        MysqlSchemaMetadata schema = new MysqlSchemaMetadata("test");
+        database.addFeature(sync);
+        if (reactive != null) {
+            database.addFeature(reactive);
+        }
+        database.addSchema(schema);
+        database.setCurrentSchema(schema);
+        RDBTableMetadata table = schema.newTable("save_or_update_test");
+        table.addColumn(column("id", true, true, true));
+        table.addColumn(column("name", false, true, true));
+        table.addColumn(column("description", false, true, true));
+        table.addColumn(column("readonly", false, false, true));
+        table.addColumn(column("blocked", false, true, false));
+        table.addColumn(column("ignored", false, true, true));
+        return table;
+    }
+
+    private static RDBColumnMetadata column(String name, boolean primary, boolean updatable, boolean saveable) {
+        RDBColumnMetadata column = new RDBColumnMetadata();
+        column.setName(name);
+        column.setAlias(name);
+        column.setPrimaryKey(primary);
+        column.setUpdatable(updatable);
+        column.setSaveable(saveable);
+        column.setLength(64);
+        column.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        return column;
+    }
+
+    private static class CapturingSyncSqlExecutor implements SyncSqlExecutor {
+        private final int[] results;
+        private int index;
+        private final List<SqlRequest> requests = new ArrayList<>();
+
+        private CapturingSyncSqlExecutor(int... results) {
+            this.results = results;
+        }
+
+        @Override
+        public int update(SqlRequest request) {
+            requests.add(request);
+            return results[Math.min(index++, results.length - 1)];
+        }
+
+        @Override
+        public void execute(SqlRequest request) {
+            requests.add(request);
+        }
+
+        @Override
+        public <T, R> R select(SqlRequest request, ResultWrapper<T, R> wrapper) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class CapturingReactiveSqlExecutor implements ReactiveSqlExecutor {
+        private final int[] results;
+        private int index;
+        private final List<SqlRequest> requests = new ArrayList<>();
+
+        private CapturingReactiveSqlExecutor(int... results) {
+            this.results = results;
+        }
+
+        @Override
+        public Mono<Integer> update(Publisher<SqlRequest> request) {
+            return Flux.from(request).map(sql -> {
+                requests.add(sql);
+                return results[Math.min(index++, results.length - 1)];
+            }).next();
+        }
+
+        @Override
+        public Mono<Void> execute(Publisher<SqlRequest> request) {
+            return Flux.from(request).doOnNext(requests::add).then();
+        }
+
+        @Override
+        public <T> Flux<T> select(Publisher<SqlRequest> request, ResultWrapper<T, ?> wrapper) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayVectorBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayVectorBranchTest.java
@@ -1,0 +1,93 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.DataType;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+import org.postgresql.util.PGobject;
+
+import java.sql.ResultSet;
+import java.util.List;
+
+public class PostgresqlArrayVectorBranchTest {
+
+    @Test
+    public void testPostgresqlArrayTypeBranches() throws Exception {
+        PostgresqlArrayType type = PostgresqlArrayType.INTEGER_ARRAY;
+        RDBColumnMetadata column = column(type);
+
+        Assert.assertArrayEquals(new Integer[]{1, 2}, (Integer[]) type.decode(List.of(1, 2)));
+        Assert.assertArrayEquals(new Integer[]{1, 2}, (Integer[]) type.decode(new Integer[]{1, 2}));
+        Assert.assertArrayEquals(new Integer[]{1, 2}, (Integer[]) type.decode("{1,2}"));
+        Assert.assertArrayEquals(new Integer[]{1, 2}, (Integer[]) type.decode("(1,2)"));
+        Assert.assertArrayEquals(new Integer[]{1, 2}, (Integer[]) type.decode("[1,2]"));
+        Assert.assertArrayEquals(new Integer[]{1, null, 3}, (Integer[]) type.decode("{1,NULL,3}"));
+        Assert.assertArrayEquals(new Integer[]{1, 2}, (Integer[]) type.decode(pgArray("{1,2}")));
+        PGobject object = new PGobject();
+        object.setType("integer[]");
+        object.setValue("{3,4}");
+        Assert.assertArrayEquals(new Integer[]{3, 4}, (Integer[]) type.decode(object));
+        Assert.assertArrayEquals(new Integer[]{5}, (Integer[]) type.decode(5));
+        Assert.assertNull(type.decode(null));
+        Assert.assertEquals("integer[]", type.createColumnDataType(column));
+        Assert.assertTrue(type.encode(List.of(1, 2)) instanceof Integer[]);
+        Assert.assertTrue(type.encode(List.of(1, 2), column) instanceof PostgresqlArrayParameter);
+    }
+
+    @Test
+    public void testVectorTypeBranches() throws Exception {
+        VectorType type = VectorType.VECTOR;
+        RDBTableMetadata table = new H2SchemaMetadata("PUBLIC").newTable("vector_test");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("v");
+
+        Assert.assertArrayEquals(new Float[]{1.0f, 2.5f}, (Float[]) type.decode(List.of(1, 2.5f)));
+        Assert.assertArrayEquals(new Float[]{1.0f, 2.0f}, (Float[]) type.decode(new float[]{1f, 2f}));
+        Assert.assertArrayEquals(new Float[]{1.0f, 2.0f}, (Float[]) type.decode("[1,2]"));
+        PGobject object = new PGobject();
+        object.setValue("{3,4}");
+        Assert.assertArrayEquals(new Float[]{3.0f, 4.0f}, (Float[]) type.decode(object));
+        Assert.assertArrayEquals(new Float[]{5.0f}, (Float[]) type.decode(5));
+        Assert.assertNull(type.decode(null));
+        Assert.assertEquals("vector(512)", type.createColumnDataType(column));
+        column.setLength(128);
+        Assert.assertEquals("vector(128)", type.createColumnDataType(column));
+    }
+
+    private static RDBColumnMetadata column(DataType type) {
+        RDBTableMetadata table = new H2SchemaMetadata("PUBLIC").newTable("array_test");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("arr");
+        column.setType(type);
+        return column;
+    }
+
+    private static java.sql.Array pgArray(String literal) {
+        return new java.sql.Array() {
+            @Override
+            public String getBaseTypeName() { return "integer"; }
+            @Override
+            public int getBaseType() { return java.sql.Types.INTEGER; }
+            @Override
+            public Object getArray() { return literal == null ? new Integer[0] : new Integer[]{1, 2}; }
+            @Override
+            public Object getArray(java.util.Map<String, Class<?>> map) { return getArray(); }
+            @Override
+            public Object getArray(long index, int count) { return getArray(); }
+            @Override
+            public Object getArray(long index, int count, java.util.Map<String, Class<?>> map) { return getArray(); }
+            @Override
+            public ResultSet getResultSet() { return null; }
+            @Override
+            public ResultSet getResultSet(java.util.Map<String, Class<?>> map) { return null; }
+            @Override
+            public ResultSet getResultSet(long index, int count) { return null; }
+            @Override
+            public ResultSet getResultSet(long index, int count, java.util.Map<String, Class<?>> map) { return null; }
+            @Override
+            public void free() { }
+        };
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayVectorCodecTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArrayVectorCodecTest.java
@@ -1,0 +1,54 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.postgresql.util.PGobject;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class PostgresqlArrayVectorCodecTest {
+
+    @Test
+    public void testArrayAndVectorStringNumberAndObjectBranches() throws SQLException {
+        Assert.assertArrayEquals(new String[]{"a", "b"}, (String[]) PostgresqlArrayType.TEXT_ARRAY.decode("{a,b}"));
+        Assert.assertArrayEquals(new String[]{"a", null, "c"}, (String[]) PostgresqlArrayType.TEXT_ARRAY.decode("[a,null,c]"));
+        Assert.assertArrayEquals(new Integer[]{1, 2, 3}, (Integer[]) PostgresqlArrayType.INTEGER_ARRAY.decode(new int[]{1, 2, 3}));
+        Assert.assertArrayEquals(new Long[]{1L, 2L}, (Long[]) PostgresqlArrayType.BIGINT_ARRAY.decode(List.of(1, 2)));
+        Assert.assertArrayEquals(new Short[]{1}, (Short[]) PostgresqlArrayType.SMALLINT_ARRAY.decode(1));
+
+        PGobject pgObject = new PGobject();
+        pgObject.setType("integer[]");
+        pgObject.setValue("{4,5}");
+        Assert.assertArrayEquals(new Integer[]{4, 5}, (Integer[]) PostgresqlArrayType.INTEGER_ARRAY.decode(pgObject));
+
+        Assert.assertArrayEquals(new String[]{"a,b", "c\"d"}, (String[]) PostgresqlArrayType.TEXT_ARRAY.decode("{\"a,b\",\"c\\\"d\"}"));
+        Assert.assertArrayEquals(new String[]{"{nested,kept}", "tail"}, (String[]) PostgresqlArrayType.TEXT_ARRAY.decode("{{nested,kept},tail}"));
+        Assert.assertArrayEquals(new Integer[]{null, 2}, (Integer[]) PostgresqlArrayType.INTEGER_ARRAY.decode("{ ,2}"));
+        Assert.assertArrayEquals(new Long[]{9L}, (Long[]) PostgresqlArrayType.BIGINT_ARRAY.decode(9.7d));
+        Assert.assertArrayEquals(new String[]{"7"}, (String[]) PostgresqlArrayType.VARCHAR_ARRAY.decode(7));
+        Assert.assertArrayEquals(new String[0], (String[]) PostgresqlArrayType.TEXT_ARRAY.decode(""));
+        Assert.assertArrayEquals(new String[0], (String[]) PostgresqlArrayType.TEXT_ARRAY.decode("{}"));
+    }
+
+    @Test
+    public void testVectorTypeStringCollectionArrayAndPgobjectBranches() throws Exception {
+        Assert.assertArrayEquals(new Float[]{1.0f, 2.5f}, (Float[]) VectorType.VECTOR.decode(List.of(1, 2.5f)));
+        Assert.assertArrayEquals(new Float[]{1.0f, 2.0f}, (Float[]) VectorType.VECTOR.decode(new float[]{1f, 2f}));
+        Assert.assertArrayEquals(new Float[]{1.0f, 2.0f}, VectorType.toFloatArray("[1,2]"));
+        Assert.assertArrayEquals(new Float[]{1.0f, 2.0f}, VectorType.toFloatArray(new Float[]{1f, 2f}));
+        Assert.assertArrayEquals(new Float[]{5.0f}, VectorType.toFloatArray(5));
+        Assert.assertNull(VectorType.toFloatArray(new Object()));
+
+        PGobject pgObject = new PGobject();
+        pgObject.setValue("{3,4}");
+        Assert.assertArrayEquals(new Float[]{3.0f, 4.0f}, (Float[]) VectorType.VECTOR.decode(pgObject));
+
+        Assert.assertArrayEquals(new Float[0], VectorType.toFloatArray(""));
+        Assert.assertArrayEquals(new Float[0], VectorType.toFloatArray("[]"));
+        Assert.assertArrayEquals(new Float[]{null, 2.0f}, VectorType.toFloatArray("[ ,2]"));
+        Assert.assertEquals("halfvec(512)", VectorType.HALF_VECTOR.createColumnDataType(new org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata()));
+        Assert.assertEquals("sparsevec(512)", VectorType.SPARSE_VECTOR.createColumnDataType(new org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata()));
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlExceptionTranslationBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlExceptionTranslationBranchTest.java
@@ -1,0 +1,53 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import io.r2dbc.postgresql.api.ErrorDetails;
+import io.r2dbc.postgresql.api.PostgresqlException;
+import io.r2dbc.postgresql.message.backend.Field;
+import org.hswebframework.ezorm.rdb.exception.DuplicateKeyException;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class PostgresqlExceptionTranslationBranchTest {
+
+    @Test
+    public void testDuplicateKeyBranches() {
+        RDBDatabaseMetadata db = new RDBDatabaseMetadata(Dialect.POSTGRES);
+        PostgresqlSchemaMetadata schema = new PostgresqlSchemaMetadata("public");
+        db.addSchema(schema); db.setCurrentSchema(schema);
+        RDBTableMetadata table = schema.newTable("t");
+        RDBColumnMetadata id = table.newColumn(); id.setName("id"); id.setPrimaryKey(true); table.addColumn(id);
+        schema.addTable(table);
+        PostgresqlR2DBCExceptionTranslation translation = PostgresqlR2DBCExceptionTranslation.of(schema);
+
+        ErrorDetails details = new ErrorDetails(List.of(
+            new Field(Field.FieldType.CODE, "23505"),
+            new Field(Field.FieldType.TABLE_NAME, "t"),
+            new Field(Field.FieldType.CONSTRAINT_NAME, "pk_t")
+        ));
+        Throwable mapped = translation.translate(new TestPostgresqlException(details));
+        Assert.assertTrue(mapped instanceof DuplicateKeyException);
+
+        ErrorDetails fallbackDetails = new ErrorDetails(List.of(
+            new Field(Field.FieldType.CODE, "23505"),
+            new Field(Field.FieldType.TABLE_NAME, "t"),
+            new Field(Field.FieldType.CONSTRAINT_NAME, "missing")
+        ));
+        Throwable fallback = translation.translate(new TestPostgresqlException(fallbackDetails));
+        Assert.assertTrue(fallback instanceof DuplicateKeyException);
+
+        RuntimeException plain = new RuntimeException("plain");
+        Assert.assertSame(plain, translation.translate(plain));
+    }
+
+    static class TestPostgresqlException extends RuntimeException implements PostgresqlException {
+        private final ErrorDetails details;
+        TestPostgresqlException(ErrorDetails details) { this.details = details; }
+        @Override public ErrorDetails getErrorDetails() { return details; }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlJsonbExistBuilderCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlJsonbExistBuilderCoverageTest.java
@@ -1,0 +1,137 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import org.hswebframework.ezorm.core.ValueCodec;
+import org.hswebframework.ezorm.core.param.Term;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.SqlFragments;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class PostgresqlJsonbExistBuilderCoverageTest {
+
+    private final PostgresqlJsonbExistTermFragmentBuilder builder = PostgresqlJsonbExistTermFragmentBuilder.exist;
+
+    @Test
+    public void testBaseExistAcceptsNativeAndPlainPathValues() {
+        RDBColumnMetadata column = jsonbColumn(null);
+
+        SqlRequest nativePath = create(column, Term.of("metadata", "exist", NativeSql.of("lower(?)", "name"))).toRequest();
+        Assert.assertEquals("jsonb_exists ( metadata , lower(?) )", nativePath.getSql());
+        Assert.assertArrayEquals(new Object[]{"name"}, nativePath.getParameters());
+
+        SqlRequest plainPath = create(column, Term.of("metadata", "exist", "profile.name")).toRequest();
+        Assert.assertEquals("jsonb_exists ( metadata , ? )", plainPath.getSql());
+        Assert.assertArrayEquals(new Object[]{"profile.name"}, plainPath.getParameters());
+    }
+
+    @Test
+    public void testAllAnyOptionsConvertListLikeValuesAndSkipEmptyValues() {
+        RDBColumnMetadata column = jsonbColumn(null);
+
+        SqlRequest allFromString = create(column, Term.of("metadata", "exist", "name,age", "all")).toRequest();
+        Assert.assertEquals("jsonb_exists_all ( metadata , array[ ?,? ])", allFromString.getSql());
+        Assert.assertArrayEquals(new Object[]{"name", "age"}, allFromString.getParameters());
+
+        SqlRequest anyFromArray = create(column, Term.of("metadata", "exist", new Object[]{"name", "age"}, "any")).toRequest();
+        Assert.assertEquals("jsonb_exists_any ( metadata , array[ ?,? ])", anyFromArray.getSql());
+        Assert.assertArrayEquals(new Object[]{"name", "age"}, anyFromArray.getParameters());
+
+        SqlRequest anyFromCollection = create(column, Term.of("metadata", "exist", Arrays.asList("name", "age"), "any")).toRequest();
+        Assert.assertEquals("jsonb_exists_any ( metadata , array[ ?,? ])", anyFromCollection.getSql());
+        Assert.assertArrayEquals(new Object[]{"name", "age"}, anyFromCollection.getParameters());
+
+        Assert.assertTrue(create(column, Term.of("metadata", "exist", null, "all")).isEmpty());
+        Assert.assertTrue(create(column, Term.of("metadata", "exist", Collections.emptyList(), "any")).isEmpty());
+    }
+
+    @Test
+    public void testContainsAndContainedEncodeObjectValuesAsJsonb() {
+        RDBColumnMetadata column = jsonbColumn(null);
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("name", "JetLinks");
+
+        SqlRequest contains = create(column, Term.of("metadata", "exist", value, "contains")).toRequest();
+        Assert.assertEquals("metadata @> ?::jsonb", contains.getSql());
+        Assert.assertEquals("{\"name\":\"JetLinks\"}", contains.getParameters()[0]);
+
+        SqlRequest contained = create(column, Term.of("metadata", "exist", "{\"name\":\"JetLinks\"}", "contained")).toRequest();
+        Assert.assertEquals("metadata <@ ?::jsonb", contained.getSql());
+        Assert.assertEquals("{\"name\":\"JetLinks\"}", contained.getParameters()[0]);
+
+        SqlRequest nullContains = create(column, Term.of("metadata", "exist", null, "contains")).toRequest();
+        Assert.assertEquals("metadata @> ?", nullContains.getSql());
+        Assert.assertArrayEquals(new Object[]{null}, nullContains.getParameters());
+    }
+
+    @Test
+    public void testContainsUsesColumnValueCodecBeforeJsonEncoding() {
+        RDBColumnMetadata nativeCodecColumn = jsonbColumn(new TestCodec(NativeSql.of("jsonb_build_object(?,?)", "name", "JetLinks")));
+        SqlRequest nativeEncoded = create(nativeCodecColumn, Term.of("metadata", "exist", Collections.singletonMap("name", "ignored"), "contains")).toRequest();
+        Assert.assertEquals("metadata @> jsonb_build_object(?,?)", nativeEncoded.getSql());
+        Assert.assertArrayEquals(new Object[]{"name", "JetLinks"}, nativeEncoded.getParameters());
+
+        RDBColumnMetadata jsonCodecColumn = jsonbColumn(new TestCodec("{\"encoded\":true}"));
+        SqlRequest jsonEncoded = create(jsonCodecColumn, Term.of("metadata", "exist", Collections.singletonMap("name", "ignored"), "contained")).toRequest();
+        Assert.assertEquals("metadata <@ ?::jsonb", jsonEncoded.getSql());
+        Assert.assertEquals("{\"encoded\":true}", jsonEncoded.getParameters()[0]);
+
+        RDBColumnMetadata nullCodecColumn = jsonbColumn(new TestCodec(null));
+        SqlRequest nullEncoded = create(nullCodecColumn, Term.of("metadata", "exist", Collections.singletonMap("name", "ignored"), "contains")).toRequest();
+        Assert.assertEquals("metadata @> ?", nullEncoded.getSql());
+        Assert.assertArrayEquals(new Object[]{null}, nullEncoded.getParameters());
+    }
+
+    @Test
+    public void testOptionPriorityMatchesRepositoryColumnSyntax() {
+        Term term = Term.of("metadata", "exist", Collections.singletonMap("name", "JetLinks"), "any", "all", "contained", "contains");
+        Assert.assertEquals("@>", PostgresqlJsonbExistTermFragmentBuilder.getOperator(term));
+
+        Term columnSyntax = new Term();
+        columnSyntax.setColumn("metadata$exist$all");
+        columnSyntax.setValue("name,age");
+        SqlRequest request = create(jsonbColumn(null), columnSyntax).toRequest();
+        Assert.assertEquals("jsonb_exists_all ( metadata , array[ ?,? ])", request.getSql());
+        Assert.assertArrayEquals(new Object[]{"name", "age"}, request.getParameters());
+    }
+
+    private SqlFragments create(RDBColumnMetadata column, Term term) {
+        return builder.createFragments("metadata", column, term);
+    }
+
+    private static RDBColumnMetadata jsonbColumn(ValueCodec<Object, Object> codec) {
+        PostgresqlSchemaMetadata schema = new PostgresqlSchemaMetadata("public");
+        RDBTableMetadata table = schema.newTable("test_jsonb_exist");
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("metadata");
+        column.setType(JsonbType.INSTANCE);
+        column.setValueCodec(codec);
+        table.addColumn(column);
+        return column;
+    }
+
+    private static class TestCodec implements ValueCodec<Object, Object> {
+        private final Object encoded;
+
+        private TestCodec(Object encoded) {
+            this.encoded = encoded;
+        }
+
+        @Override
+        public Object encode(Object value) {
+            return encoded;
+        }
+
+        @Override
+        public Object decode(Object data) {
+            return data;
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlPaginatorBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlPaginatorBranchTest.java
@@ -1,0 +1,15 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.BlockSqlFragments;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.PrepareSqlFragments;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PostgresqlPaginatorBranchTest {
+    @Test
+    public void testBlockAndAppendableBranches() {
+        PostgresqlPaginator paginator = new PostgresqlPaginator();
+        Assert.assertTrue(paginator.doPaging(BlockSqlFragments.of(), 2, 10).toRequest().getSql().contains("limit ? offset ?"));
+        Assert.assertTrue(paginator.doPaging(PrepareSqlFragments.of("select * from t"), 1, 5).toRequest().getSql().contains("limit ? offset ?"));
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlSaveOrUpdateOperatorTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlSaveOrUpdateOperatorTest.java
@@ -1,0 +1,153 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.executor.SyncSqlExecutor;
+import org.hswebframework.ezorm.rdb.executor.reactive.ReactiveSqlExecutor;
+import org.hswebframework.ezorm.rdb.executor.wrapper.ResultWrapper;
+import org.hswebframework.ezorm.rdb.mapping.defaults.SaveResult;
+import org.hswebframework.ezorm.rdb.metadata.JdbcDataType;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBDatabaseMetadata;
+import org.hswebframework.ezorm.rdb.metadata.RDBTableMetadata;
+import org.hswebframework.ezorm.rdb.metadata.dialect.Dialect;
+import org.hswebframework.ezorm.rdb.operator.builder.fragments.NativeSql;
+import org.hswebframework.ezorm.rdb.operator.dml.upsert.UpsertColumn;
+import org.hswebframework.ezorm.rdb.operator.dml.upsert.UpsertOperatorParameter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.sql.JDBCType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PostgresqlSaveOrUpdateOperatorTest {
+
+    @Test
+    public void testSyncBuildsPerRowUpsertAndClassifiesSaveResult() {
+        CapturingSyncSqlExecutor executor = new CapturingSyncSqlExecutor(0, 2);
+        RDBTableMetadata table = newTable(executor, null);
+        SaveResult result = new PostgresqlSaveOrUpdateOperator(table).execute(parameter()).sync();
+
+        Assert.assertEquals(2, result.getAdded());
+        Assert.assertEquals(1, result.getUpdated());
+        Assert.assertEquals(2, executor.requests.size());
+        Assert.assertTrue(executor.requests.get(0).getSql().contains("on conflict ( id ) do update set"));
+        Assert.assertTrue(executor.requests.get(0).getSql().contains("\"name\" = upper(?)"));
+        Assert.assertTrue(executor.requests.get(0).getSql().contains("\"description\" = ?"));
+        Assert.assertTrue(Arrays.asList(executor.requests.get(0).getParameters()).contains("jetlinks"));
+    }
+
+    @Test
+    public void testReactiveBuildsPerRowUpsertAndClassifiesSaveResult() {
+        CapturingReactiveSqlExecutor reactive = new CapturingReactiveSqlExecutor(1, 0);
+        RDBTableMetadata table = newTable(new CapturingSyncSqlExecutor(1), reactive);
+        SaveResult result = new PostgresqlSaveOrUpdateOperator(table).execute(parameter()).reactive().block();
+
+        Assert.assertEquals(1, result.getAdded());
+        Assert.assertEquals(1, result.getUpdated());
+        Assert.assertEquals(2, reactive.requests.size());
+    }
+
+    private static UpsertOperatorParameter parameter() {
+        UpsertOperatorParameter parameter = new UpsertOperatorParameter();
+        parameter.getColumns().add(UpsertColumn.of("id", false));
+        parameter.getColumns().add(UpsertColumn.of("name", false));
+        parameter.getColumns().add(UpsertColumn.of("description", false));
+        parameter.getColumns().add(UpsertColumn.of("readonly", false));
+        parameter.getColumns().add(UpsertColumn.of("blocked", false));
+        parameter.getColumns().add(UpsertColumn.of("ignored", true));
+        parameter.getColumns().add(UpsertColumn.of("ghost", false));
+        parameter.getValues().add(Arrays.asList("1", NativeSql.of("upper(?)", "jetlinks"), "desc", "ro", "blocked", "ignored", "ghost"));
+        parameter.getValues().add(Arrays.asList("2", null));
+        return parameter;
+    }
+
+    private static RDBTableMetadata newTable(CapturingSyncSqlExecutor sync, CapturingReactiveSqlExecutor reactive) {
+        RDBDatabaseMetadata database = new RDBDatabaseMetadata(Dialect.POSTGRES);
+        PostgresqlSchemaMetadata schema = new PostgresqlSchemaMetadata("public");
+        database.addFeature(sync);
+        if (reactive != null) {
+            database.addFeature(reactive);
+        }
+        database.addSchema(schema);
+        database.setCurrentSchema(schema);
+        RDBTableMetadata table = schema.newTable("save_or_update_test");
+        table.addColumn(column("id", true, true, true));
+        table.addColumn(column("name", false, true, true));
+        table.addColumn(column("description", false, true, true));
+        table.addColumn(column("readonly", false, false, true));
+        table.addColumn(column("blocked", false, true, false));
+        table.addColumn(column("ignored", false, true, true));
+        return table;
+    }
+
+    private static RDBColumnMetadata column(String name, boolean primary, boolean updatable, boolean saveable) {
+        RDBColumnMetadata column = new RDBColumnMetadata();
+        column.setName(name);
+        column.setAlias(name);
+        column.setPrimaryKey(primary);
+        column.setUpdatable(updatable);
+        column.setSaveable(saveable);
+        column.setLength(64);
+        column.setType(JdbcDataType.of(JDBCType.VARCHAR, String.class));
+        return column;
+    }
+
+    private static class CapturingSyncSqlExecutor implements SyncSqlExecutor {
+        private final int[] results;
+        private int index;
+        private final List<SqlRequest> requests = new ArrayList<>();
+
+        private CapturingSyncSqlExecutor(int... results) {
+            this.results = results;
+        }
+
+        @Override
+        public int update(SqlRequest request) {
+            requests.add(request);
+            return results[Math.min(index++, results.length - 1)];
+        }
+
+        @Override
+        public void execute(SqlRequest request) {
+            requests.add(request);
+        }
+
+        @Override
+        public <T, R> R select(SqlRequest request, ResultWrapper<T, R> wrapper) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class CapturingReactiveSqlExecutor implements ReactiveSqlExecutor {
+        private final int[] results;
+        private int index;
+        private final List<SqlRequest> requests = new ArrayList<>();
+
+        private CapturingReactiveSqlExecutor(int... results) {
+            this.results = results;
+        }
+
+        @Override
+        public Mono<Integer> update(Publisher<SqlRequest> request) {
+            return Flux.from(request).map(sql -> {
+                requests.add(sql);
+                return results[Math.min(index++, results.length - 1)];
+            }).next();
+        }
+
+        @Override
+        public Mono<Void> execute(Publisher<SqlRequest> request) {
+            return Flux.from(request).doOnNext(requests::add).then();
+        }
+
+        @Override
+        public <T> Flux<T> select(Publisher<SqlRequest> request, ResultWrapper<T, ?> wrapper) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlVectorDistanceFunctionFragmentBuilderBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlVectorDistanceFunctionFragmentBuilderBranchTest.java
@@ -1,0 +1,34 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PostgresqlVectorDistanceFunctionFragmentBuilderBranchTest {
+    @Test
+    public void testCreateBranches() {
+        PostgresqlVectorDistanceFunctionFragmentBuilder builder = new PostgresqlVectorDistanceFunctionFragmentBuilder();
+        RDBColumnMetadata column = new H2SchemaMetadata("PUBLIC").newTable("v").newColumn(); column.setName("v");
+        Assert.assertTrue(builder.create("t.v", column, Map.of("vectorValue", new float[]{1,2,3})).isNotEmpty());
+        Map<String, Object> none = new HashMap<>();
+        none.put("termType", VectorTermType.vector_ip.name());
+        none.put("vectorValue", null);
+        Assert.assertTrue(builder.create("t.v", column, none).isEmpty());
+        Map<String, Object> empty = new HashMap<>();
+        empty.put("termType", 1);
+        empty.put("vectorValue", null);
+        Assert.assertTrue(builder.create("t.v", column, empty).isEmpty());
+        try {
+            Map<String, Object> bad = new HashMap<>();
+            bad.put("termType", "unknown");
+            bad.put("vectorValue", new float[]{1,2,3});
+            builder.create("t.v", column, bad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignore) {
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/VectorTypeBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/VectorTypeBranchTest.java
@@ -1,0 +1,27 @@
+package org.hswebframework.ezorm.rdb.supports.postgres;
+
+import io.r2dbc.postgresql.codec.Vector;
+import org.hswebframework.ezorm.rdb.metadata.RDBColumnMetadata;
+import org.hswebframework.ezorm.rdb.supports.h2.H2SchemaMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+import org.postgresql.util.PGobject;
+
+public class VectorTypeBranchTest {
+
+    @Test
+    public void testToFloatArrayBranches() throws Exception {
+        Assert.assertArrayEquals(new Float[]{1f, 2f}, VectorType.toFloatArray(java.util.List.of(1, 2)));
+        Assert.assertArrayEquals(new Float[]{1f, 2f}, VectorType.toFloatArray(new int[]{1, 2}));
+        Assert.assertArrayEquals(new Float[]{1f, 2f}, VectorType.toFloatArray("[1,2]"));
+        Assert.assertArrayEquals(new Float[]{1f}, VectorType.toFloatArray(1));
+        Assert.assertNull(VectorType.toFloatArray(null));
+
+        VectorType type = VectorType.VECTOR;
+        Assert.assertArrayEquals(new Float[]{3f, 4f}, (Float[]) type.decode(Vector.of(3f, 4f)));
+        PGobject obj = new PGobject(); obj.setValue("{5,6}"); obj.setType("vector");
+        Assert.assertArrayEquals(new Float[]{5f, 6f}, (Float[]) type.decode(obj));
+        RDBColumnMetadata column = new H2SchemaMetadata("PUBLIC").newTable("v").newColumn(); column.setName("v");
+        Assert.assertEquals("vector(512)", type.createColumnDataType(column));
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/AnnotationUtilsTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/AnnotationUtilsTest.java
@@ -1,0 +1,86 @@
+package org.hswebframework.ezorm.rdb.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+public class AnnotationUtilsTest {
+
+    @Test
+    public void testGetFiledByDescriptorAcrossHierarchyAndCapitalization() throws Exception {
+        PropertyDescriptor descriptor = new PropertyDescriptor("name", Child.class, "getName", "setName");
+        Assert.assertTrue(AnnotationUtils.getFiledByDescriptor(Child.class, descriptor).isPresent());
+        Assert.assertEquals("name", AnnotationUtils.getFiledByDescriptor(Child.class, descriptor).get().getName());
+
+        PropertyDescriptor capitalized = new PropertyDescriptor("Name", Child.class, "getName", "setName");
+        Assert.assertTrue(AnnotationUtils.getFiledByDescriptor(Child.class, capitalized).isPresent());
+
+        PropertyDescriptor missing = new PropertyDescriptor("missing", Child.class, "getName", "setName");
+        Assert.assertFalse(AnnotationUtils.getFiledByDescriptor(Child.class, missing).isPresent());
+    }
+
+    @Test
+    public void testGetAnnotationFromMethodFieldAndSuperclass() throws Exception {
+        PropertyDescriptor descriptor = new PropertyDescriptor("name", Child.class, "getName", "setName");
+        Assert.assertEquals(Marker.class, AnnotationUtils.getAnnotation(Child.class, descriptor, Marker.class).annotationType());
+        Assert.assertEquals(Marker.class, AnnotationUtils.getAnnotation(Child.class, descriptor, Marker.class).annotationType());
+
+        Method method = Child.class.getMethod("getName");
+        Assert.assertEquals(Marker.class, AnnotationUtils.getAnnotation(method, Marker.class).annotationType());
+        Assert.assertNull(AnnotationUtils.getAnnotation(NoMarker.class, Marker.class));
+    }
+
+    @Test
+    public void testGetAnnotationsDeduplicatesByType() throws IntrospectionException {
+        PropertyDescriptor descriptor = new PropertyDescriptor("name", Child.class, "getName", "setName");
+        Set<java.lang.annotation.Annotation> annotations = AnnotationUtils.getAnnotations(Child.class, descriptor);
+        Assert.assertEquals(1, annotations.stream().filter(a -> a.annotationType() == Marker.class).count());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+    public @interface Marker {
+    }
+
+    public static class Base {
+        @Marker
+        private String name;
+
+        @Marker
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static class Child extends Base {
+        @Override
+        @Marker
+        public String getName() {
+            return super.getName();
+        }
+
+        public void setName(String name) {
+            try {
+                java.lang.reflect.Field field = Base.class.getDeclaredField("name");
+                field.setAccessible(true);
+                field.set(this, name);
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    public static class NoMarker {
+        public String getOther() {
+            return "x";
+        }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/ExceptionUtilsBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/ExceptionUtilsBranchTest.java
@@ -1,0 +1,63 @@
+package org.hswebframework.ezorm.rdb.utils;
+
+import org.hswebframework.ezorm.core.meta.FeatureSupportedMetadata;
+import org.hswebframework.ezorm.rdb.operator.ExceptionTranslation;
+import org.junit.Assert;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import org.reactivestreams.Publisher;
+
+import org.hswebframework.ezorm.core.meta.Feature;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class ExceptionUtilsBranchTest {
+
+    @Test
+    public void testTranslationWithFeatureAndMissingFeatureBranches() {
+        FeatureSupportedMetadata metadata = new TestMetadata(new RuntimeException("translated"));
+        RuntimeException source = new RuntimeException("source");
+        Throwable translated = ExceptionUtils.translation(metadata, source);
+        Assert.assertEquals("translated", translated.getMessage());
+
+        FeatureSupportedMetadata empty = new TestMetadata(null);
+        Assert.assertSame(source, ExceptionUtils.translation(empty, source));
+    }
+
+    @Test
+    public void testTranslationSupplierAndPublisherBranches() {
+        FeatureSupportedMetadata metadata = new TestMetadata(new IllegalStateException("boom"));
+        try {
+            ExceptionUtils.translation(() -> { throw new IllegalArgumentException("bad"); }, metadata);
+            Assert.fail();
+        } catch (Throwable err) {
+            Assert.assertEquals("boom", err.getMessage());
+        }
+
+        Function<Publisher<String>, Publisher<String>> fn = ExceptionUtils.translation(metadata);
+        Assert.assertEquals("boom", StepVerifierLike.blockError((Mono<String>) fn.apply(Mono.error(new IllegalArgumentException("bad")))).getMessage());
+        Assert.assertEquals("boom", StepVerifierLike.blockError((Flux<String>) fn.apply(Flux.error(new IllegalArgumentException("bad")))).getMessage());
+    }
+
+    private static class TestMetadata implements FeatureSupportedMetadata {
+        private final Map<String, Feature> features = new HashMap<>();
+        private TestMetadata(Throwable translated) {
+            if (translated != null) {
+                features.put(ExceptionTranslation.ID.getId(), new ExceptionTranslation() {
+                    @Override public Throwable translate(Throwable e) { return translated; }
+                });
+            }
+        }
+        @Override public Map<String, Feature> getFeatures() { return features; }
+        @Override public void addFeature(Feature feature) { features.put(feature.getId(), feature); }
+    }
+
+    private static class StepVerifierLike {
+        static Throwable blockError(Mono<?> mono) { try { mono.block(); throw new AssertionError(); } catch (Throwable e) { return e; } }
+        static Throwable blockError(Flux<?> flux) { try { flux.blockLast(); throw new AssertionError(); } catch (Throwable e) { return e; } }
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/FlatListTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/FlatListTest.java
@@ -12,13 +12,11 @@ public class FlatListTest {
 
     @Test
     public void test() {
-        FlatList<Integer> list = new FlatList<>(
-            Arrays.asList(
-                Arrays.asList(1, 2, 3),
-                Arrays.asList(4, 5, 6),
-                Arrays.asList(7, 8, 9)
-            )
-        );
+        java.util.List<java.util.List<Integer>> nested = new java.util.ArrayList<>();
+        nested.add(new java.util.ArrayList<>(Arrays.asList(1, 2, 3)));
+        nested.add(new java.util.ArrayList<>(Arrays.asList(4, 5, 6)));
+        nested.add(new java.util.ArrayList<>(Arrays.asList(7, 8, 9)));
+        FlatList<Integer> list = new FlatList<>(nested);
         list.listIterator(3).forEachRemaining(System.out::println);
 
         assertEquals(Integer.valueOf(1), list.get(0));
@@ -30,6 +28,31 @@ public class FlatListTest {
         assertEquals(Arrays.asList(3, 4, 5), list.subList(2, 5));
 
         assertArrayEquals(new Integer[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, list.toArray());
+
+        list.set(0, 10);
+        assertEquals(Integer.valueOf(10), list.get(0));
+        list.add(11);
+        list.addAll(Arrays.asList(12, 13));
+        assertEquals(12, list.size());
+        assertArrayEquals(new Integer[]{10, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13}, list.toArray(new Integer[0]));
+        Integer[] larger = new Integer[20];
+        assertSame(larger, list.toArray(larger));
+        assertEquals(Integer.valueOf(13), larger[11]);
+
+        try {
+            list.get(99);
+            fail("out of range index should fail");
+        } catch (IndexOutOfBoundsException e) {
+            assertTrue(e.getMessage().contains("Index: 99"));
+        }
+
+        java.util.Iterator<Integer> empty = new FlatList<Integer>(java.util.Collections.emptyList()).iterator();
+        assertFalse(empty.hasNext());
+        try {
+            empty.next();
+            fail("empty iterator should fail");
+        } catch (java.util.NoSuchElementException ignore) {
+        }
 
     }
 }

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/PropertiesUtilsTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/PropertiesUtilsTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 
 import java.beans.PropertyDescriptor;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -21,6 +23,19 @@ public class PropertiesUtilsTest {
         for (PropertyDescriptor propertyDescriptor : descriptor) {
             System.out.println(propertyDescriptor.getName());
         }
+    }
+
+    @Test
+    public void testConvertListAndGetPropertyField(){
+        assertTrue(PropertiesUtils.convertList(null).isEmpty());
+        assertEquals(Arrays.asList("a", "b"), PropertiesUtils.convertList(new String[]{"a", "b"}));
+        List<Object> list = PropertiesUtils.convertList(Collections.singletonList("x"));
+        assertEquals(Collections.singletonList("x"), list);
+        assertEquals(Collections.singletonList("y"), PropertiesUtils.convertList("y"));
+
+        assertTrue(PropertiesUtils.getPropertyField(TestEntity.class, "name").isPresent());
+        assertTrue(PropertiesUtils.getPropertyField(TestEntity.class, "id").isPresent());
+        assertFalse(PropertiesUtils.getPropertyField(TestEntity.class, "missing").isPresent());
     }
 
     @Getter

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/SqlUtilsBranchTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/SqlUtilsBranchTest.java
@@ -1,0 +1,44 @@
+package org.hswebframework.ezorm.rdb.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SqlUtilsBranchTest {
+
+    @Test
+    public void testReplaceSqlParameterKeepsQuotedStringsCommentsAndPgOperators() {
+        String sql = "select '?', \"?\", col ? 'k', col ?| array['a'], col ?& array['b'], col ?! 'c', col = ? -- comment ?\n/* block ? */ and v = ?";
+        String result = SqlUtils.replaceSqlParameter(sql, 0, i -> i == 0 ? "1" : "2");
+        Assert.assertEquals("select '?', \"?\", col ? 'k', col ?| array['a'], col ?& array['b'], col ?! 'c', col = 1 -- comment ?\n/* block ? */ and v = 2", result);
+    }
+
+    @Test
+    public void testReplaceSqlParameterDetectsArrayOperatorAndLeavesUnboundWhenReplacerMissing() {
+        String sql = "select data ? array['a'] and x = ? and y = ?";
+        String result = SqlUtils.replaceSqlParameter(sql, 0, i -> i == 0 ? "1" : null);
+        Assert.assertEquals("select data ? array['a'] and x = 1 and y = null", result);
+    }
+
+    @Test
+    public void testToNativeSqlHandlesNullAndDates() {
+        String sql = SqlUtils.toNativeSql("select * from t where a=? and b=? and c=? and d=?", 1, true, new java.util.Date(0), null);
+        Assert.assertTrue(sql.contains("1"));
+        Assert.assertTrue(sql.contains("true"));
+        Assert.assertTrue(sql.contains("1970-01-01 08:00:00") || sql.contains("1970-01-01 00:00:00"));
+        Assert.assertTrue(sql.contains("null"));
+    }
+
+    @Test
+    public void testReplaceSqlParameterEscapedQuotesAndOperatorBoundaries() {
+        Assert.assertEquals("select 'it''s ?' and x=1",
+                            SqlUtils.replaceSqlParameter("select 'it''s ?' and x=?", 0, i -> "1"));
+        Assert.assertEquals("select \"a\"\"?\" and x=1",
+                            SqlUtils.replaceSqlParameter("select \"a\"\"?\" and x=?", 0, i -> "1"));
+        Assert.assertEquals("select ?",
+                            SqlUtils.replaceSqlParameter("select ?", 0, i -> "?"));
+        Assert.assertEquals("select 1",
+                            SqlUtils.replaceSqlParameter("select ?", 0, i -> "1"));
+        Assert.assertEquals("select x 1 key",
+                            SqlUtils.replaceSqlParameter("select x ? key", 0, i -> "1"));
+    }
+}

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/SqlUtilsCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/SqlUtilsCoverageTest.java
@@ -1,0 +1,130 @@
+package org.hswebframework.ezorm.rdb.utils;
+
+import org.hswebframework.ezorm.rdb.executor.NullValue;
+import org.hswebframework.ezorm.rdb.executor.PrepareSqlRequest;
+import org.hswebframework.ezorm.rdb.executor.SqlRequest;
+import org.hswebframework.ezorm.rdb.metadata.JdbcDataType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.sql.JDBCType;
+
+public class SqlUtilsCoverageTest {
+
+    @Test
+    public void testSqlParameterToStringBranches() {
+        Assert.assertEquals("", SqlUtils.sqlParameterToString(null));
+        Assert.assertEquals("1(Integer),null(null),null(String),foo(String)", SqlUtils.sqlParameterToString(new Object[]{1, null, NullValue.of(JdbcDataType.of(JDBCType.VARCHAR, String.class)), "foo"}));
+    }
+
+    @Test
+    public void testPrintSqlBranches() {
+        CapturingLogger disabled = new CapturingLogger(false);
+        SqlUtils.printSql(disabled, PrepareSqlRequest.of("select 1", new Object[0]));
+        Assert.assertFalse(disabled.called);
+
+        CapturingLogger enabled = new CapturingLogger(true);
+        SqlUtils.printSql(enabled, PrepareSqlRequest.of("select ?", new Object[]{1}));
+        Assert.assertTrue(enabled.called);
+        Assert.assertEquals("select * from t", SqlUtils.toNativeSql("select * from t", (Object[]) null));
+    }
+
+    @Test
+    public void testReplaceSqlParameterCornerBranches() {
+        Assert.assertEquals("1", SqlUtils.replaceSqlParameter("?", 0, i -> "1"));
+        Assert.assertEquals("x 1 y", SqlUtils.replaceSqlParameter("x ? y", 0, i -> "1"));
+        Assert.assertEquals("x ? 1", SqlUtils.replaceSqlParameter("x ? ?", 0, i -> "1"));
+        Assert.assertEquals("x ?? y", SqlUtils.replaceSqlParameter("x ?? y", 0, i -> "1"));
+        Assert.assertEquals("x ? array['a']", SqlUtils.replaceSqlParameter("x ? array['a']", 0, i -> "1"));
+        Assert.assertEquals("x ? 'a'", SqlUtils.replaceSqlParameter("x ? 'a'", 0, i -> "1"));
+        Assert.assertEquals("x ?| y", SqlUtils.replaceSqlParameter("x ?| y", 0, i -> "1"));
+        Assert.assertEquals("x ?& y", SqlUtils.replaceSqlParameter("x ?& y", 0, i -> "1"));
+        Assert.assertEquals("x ?! y", SqlUtils.replaceSqlParameter("x ?! y", 0, i -> "1"));
+        Assert.assertEquals("x 1\n y", SqlUtils.replaceSqlParameter("x ?\n y", 0, i -> "1"));
+        Assert.assertEquals("x /* ? */ y", SqlUtils.replaceSqlParameter("x /* ? */ y", 0, i -> "1"));
+        Assert.assertEquals("x \"?\" y", SqlUtils.replaceSqlParameter("x \"?\" y", 0, i -> "1"));
+    }
+
+    @Test
+    public void testCreateQuestionMarksBoundaryBranches() throws Exception {
+        java.lang.reflect.Field field = SqlUtils.class.getDeclaredField("Q_M_CACHE");
+        field.setAccessible(true);
+        int cacheSize = ((Object[]) field.get(null)).length;
+        Assert.assertTrue(SqlUtils.createQuestionMarks(0).isEmpty());
+        Assert.assertEquals("?", SqlUtils.createQuestionMarks(1).toRequest().getSql());
+        Assert.assertEquals("?,?", SqlUtils.createQuestionMarks(2).toRequest().getSql());
+        Assert.assertEquals(1, SqlUtils.createQuestionMarks(1).getSql().size());
+        Assert.assertTrue(SqlUtils.createQuestionMarks(cacheSize - 1).toRequest().getSql().contains("?"));
+        Assert.assertTrue(SqlUtils.createQuestionMarks(cacheSize).toRequest().getSql().contains("?"));
+        Assert.assertTrue(SqlUtils.createQuestionMarks(cacheSize + 1).toRequest().getSql().contains("?"));
+    }
+
+    private static class CapturingLogger implements Logger {
+        private final boolean enabled;
+        private boolean called;
+
+        private CapturingLogger(boolean enabled) { this.enabled = enabled; }
+        @Override public boolean isDebugEnabled() { return enabled; }
+        @Override public void debug(String msg, Object... arguments) { called = true; }
+        @Override public void debug(String msg) { called = true; }
+        @Override public void debug(String format, Object arg) { called = true; }
+        @Override public void debug(String format, Object arg1, Object arg2) { called = true; }
+        @Override public void debug(String msg, Throwable t) { called = true; }
+        @Override public boolean isTraceEnabled() { return false; }
+        @Override public void trace(String msg) { }
+        @Override public void trace(String format, Object arg) { }
+        @Override public void trace(String format, Object arg1, Object arg2) { }
+        @Override public void trace(String format, Object... arguments) { }
+        @Override public void trace(String msg, Throwable t) { }
+        @Override public boolean isTraceEnabled(org.slf4j.Marker marker) { return false; }
+        @Override public void trace(org.slf4j.Marker marker, String msg) { }
+        @Override public void trace(org.slf4j.Marker marker, String format, Object arg) { }
+        @Override public void trace(org.slf4j.Marker marker, String format, Object arg1, Object arg2) { }
+        @Override public void trace(org.slf4j.Marker marker, String format, Object... argArray) { }
+        @Override public void trace(org.slf4j.Marker marker, String msg, Throwable t) { }
+        @Override public boolean isDebugEnabled(org.slf4j.Marker marker) { return enabled; }
+        @Override public void debug(org.slf4j.Marker marker, String msg) { called = true; }
+        @Override public void debug(org.slf4j.Marker marker, String format, Object arg) { called = true; }
+        @Override public void debug(org.slf4j.Marker marker, String format, Object arg1, Object arg2) { called = true; }
+        @Override public void debug(org.slf4j.Marker marker, String format, Object... arguments) { called = true; }
+        @Override public void debug(org.slf4j.Marker marker, String msg, Throwable t) { called = true; }
+        @Override public boolean isInfoEnabled() { return false; }
+        @Override public void info(String msg) { }
+        @Override public void info(String format, Object arg) { }
+        @Override public void info(String format, Object arg1, Object arg2) { }
+        @Override public void info(String format, Object... arguments) { }
+        @Override public void info(String msg, Throwable t) { }
+        @Override public boolean isInfoEnabled(org.slf4j.Marker marker) { return false; }
+        @Override public void info(org.slf4j.Marker marker, String msg) { }
+        @Override public void info(org.slf4j.Marker marker, String format, Object arg) { }
+        @Override public void info(org.slf4j.Marker marker, String format, Object arg1, Object arg2) { }
+        @Override public void info(org.slf4j.Marker marker, String format, Object... arguments) { }
+        @Override public void info(org.slf4j.Marker marker, String msg, Throwable t) { }
+        @Override public boolean isWarnEnabled() { return false; }
+        @Override public void warn(String msg) { }
+        @Override public void warn(String format, Object arg) { }
+        @Override public void warn(String format, Object... arguments) { }
+        @Override public void warn(String format, Object arg1, Object arg2) { }
+        @Override public void warn(String msg, Throwable t) { }
+        @Override public boolean isWarnEnabled(org.slf4j.Marker marker) { return false; }
+        @Override public void warn(org.slf4j.Marker marker, String msg) { }
+        @Override public void warn(org.slf4j.Marker marker, String format, Object arg) { }
+        @Override public void warn(org.slf4j.Marker marker, String format, Object arg1, Object arg2) { }
+        @Override public void warn(org.slf4j.Marker marker, String format, Object... arguments) { }
+        @Override public void warn(org.slf4j.Marker marker, String msg, Throwable t) { }
+        @Override public boolean isErrorEnabled() { return false; }
+        @Override public void error(String msg) { }
+        @Override public void error(String format, Object arg) { }
+        @Override public void error(String format, Object arg1, Object arg2) { }
+        @Override public void error(String format, Object... arguments) { }
+        @Override public void error(String msg, Throwable t) { }
+        @Override public boolean isErrorEnabled(org.slf4j.Marker marker) { return false; }
+        @Override public void error(org.slf4j.Marker marker, String msg) { }
+        @Override public void error(org.slf4j.Marker marker, String format, Object arg) { }
+        @Override public void error(org.slf4j.Marker marker, String format, Object arg1, Object arg2) { }
+        @Override public void error(org.slf4j.Marker marker, String format, Object... arguments) { }
+        @Override public void error(org.slf4j.Marker marker, String msg, Throwable t) { }
+        @Override public String getName() { return "test"; }
+    }
+}


### PR DESCRIPTION
## 目的

持续完善 `hsweb-easy-orm-rdb` 的测试覆盖率，将分支覆盖率提升到 80%+，并尽量围绕真实 ORM 使用场景补充测试，而不是单纯为覆盖率造分支。

## 主要变更

- 补充 core 查询 DSL、嵌套条件、元数据工具等基础行为测试。
- 补充 rdb 核心场景测试：
  - JSON/JSONB 条件、JSON codec、严格 term 模式。
  - PostgreSQL 数组、向量、JSONB exists 与 upsert 分支。
  - MySQL、SQLServer、Kingbase、PostgreSQL 分页/异常/upsert/DDL 分支。
  - 查询列构造、QueryTerms、批量 insert/update、外键条件、元数据列行为。
  - SQL 参数替换、注解/属性/异常工具等工具类边界。
- 修正 Kingbase MySQL 建表 SQL 中 comment 批量语句追加顺序，避免 comment 语句在主 create table SQL 设置前被覆盖。

## 测试证据

执行命令：

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl hsweb-easy-orm-rdb -am test -DskipTests=false
```

结果：

- Tests run: 551
- Failures: 0
- Errors: 0
- Skipped: 2
- Reactor: BUILD SUCCESS

覆盖率（`hsweb-easy-orm-rdb/target/site/jacoco/jacoco.csv`）：

- Instruction: 85.07%（39492/46423）
- Branch: 80.06%（2839/3546）
- Line: 86.13%（8206/9527）
- Complexity: 72.88%（3249/4458）
- Method: 78.49%（2098/2673）

## 集成测试

本模块现有测试集中包含基于 Testcontainers 的 H2、openGauss、Oracle、PostgreSQL、SQLServer、MySQL 等数据库相关用例，本次完整模块测试已执行通过。部分环境输出中存在容器启动和数据库预期异常分支日志，但最终测试结果为 0 failures / 0 errors。

## 兼容性与风险

- 主体为测试覆盖率增强，不改变公开 API。
- 生产代码仅调整 Kingbase MySQL 建表 comment 批量语句的保留顺序，属于修正已有建表 SQL 构造行为。
- 不涉及新增常驻任务、缓存、队列或后台执行器；MBean 不适用。
- 不涉及业务链路埋点；TraceHolder 不适用。
