### PR TITLE
fix(rdb): 修复 PostgreSQL int2 类型映射

### DIFF
--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlDialect.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlDialect.java
@@ -79,7 +79,7 @@ public class PostgresqlDialect extends DefaultDialect {
 
         registerDataType("int8", JdbcDataType.of(JDBCType.BIGINT, Long.class));
         registerDataType("int4", JdbcDataType.of(JDBCType.INTEGER, Integer.class));
-        registerDataType("int2", JdbcDataType.of(JDBCType.SMALLINT, Byte.class));
+        registerDataType("int2", JdbcDataType.of(JDBCType.SMALLINT, Short.class));
         registerDataType("int", JdbcDataType.of(JDBCType.INTEGER, Integer.class));
         registerDataType("float8", JdbcDataType.of(JDBCType.DOUBLE, Double.class));
         registerDataType("float4", JdbcDataType.of(JDBCType.FLOAT, Float.class));

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArraySupportTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlArraySupportTest.java
@@ -37,6 +37,23 @@ public class PostgresqlArraySupportTest {
         Assert.assertArrayEquals(new Long[]{1L, null, 3L}, (Long[]) PostgresqlArrayType.BIGINT_ARRAY.decode("{1,NULL,3}"));
     }
 
+
+    @Test
+    public void testInt2ColumnTypeMapping() {
+        RDBSchemaMetadata schema = createSchema();
+        RDBTableMetadata table = schema.newTable("test_smallint");
+        schema.addTable(table);
+
+        RDBColumnMetadata column = table.newColumn();
+        column.setName("object_type");
+        column.setOwner(table);
+        column.setType(table.getDialect().convertDataType("int2"));
+        table.addColumn(column);
+
+        Assert.assertEquals("int2", column.getDataType());
+        Assert.assertEquals(Short.class, column.getJavaType());
+    }
+
     @Test
     public void testArrayColumnType() {
         RDBSchemaMetadata schema = createSchema();


### PR DESCRIPTION
## 概述
- 修复 PostgreSQL 方言中 `int2` 被错误映射为 `Byte.class` 的问题
- 将 `int2` 调整为 `Short.class`
- 补充 `PostgresqlArraySupportTest` 回归测试，验证 `int2` 列类型映射结果

## 背景
在上层 retrieval 的 binding 模式大样本验证中，`smallint/int2` 标签值如 `1000` 被写成 `-24`，导致：
- 标签精准筛选准确率异常
- 向量 + 标签 + 全文混合检索准确率异常

根因定位到 `PostgresqlDialect` 对 `int2` 的 Java 类型注册错误。

## 验证
已本地执行：
```bash
mvn -Dsurefire.failIfNoSpecifiedTests=false -Dtest=PostgresqlArraySupportTest -pl hsweb-easy-orm-rdb -am test
```

结果：
- `PostgresqlArraySupportTest`: 4 passed

## 影响
- 修复 PostgreSQL `smallint/int2` 数值列在 easy-orm 下的类型映射
- 对依赖该映射的上层模块（如 retrieval-pg 的绑定表标签写入/读取）生效
