### PR TITLE
fix(PostgreSQL): 使用 jsonb 可索引操作符查询键

### DIFF
--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutor.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/executor/jdbc/JdbcSqlExecutor.java
@@ -7,6 +7,7 @@ import org.hswebframework.ezorm.rdb.executor.BatchSqlRequest;
 import org.hswebframework.ezorm.rdb.executor.DefaultColumnWrapperContext;
 import org.hswebframework.ezorm.rdb.executor.SqlRequest;
 import org.hswebframework.ezorm.rdb.executor.wrapper.ResultWrapper;
+import org.hswebframework.ezorm.rdb.supports.postgres.PostgresqlDriverUtils;
 import org.slf4j.Logger;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
@@ -43,7 +44,7 @@ public abstract class JdbcSqlExecutor {
         try {
             int count = 0;
             if (!request.isEmpty()) {
-                statement = connection.prepareStatement(request.getSql());
+                statement = createStatement(connection, request.getSql());
                 preparedStatementParameter(statement, request.getParameters());
                 count += statement.executeUpdate();
                 logger.debug("==>    Updated: {}", count);
@@ -57,7 +58,7 @@ public abstract class JdbcSqlExecutor {
                             releaseStatement(statement);
                         }
                         printSql(logger, batch);
-                        statement = connection.prepareStatement(batch.getSql());
+                        statement = createStatement(connection, batch.getSql());
                         preparedStatementParameter(statement, batch.getParameters());
                         int rows = statement.executeUpdate();
                         count += rows;
@@ -90,7 +91,7 @@ public abstract class JdbcSqlExecutor {
         try {
             if (!request.isEmpty()) {
                 printSql(logger, request);
-                statement = connection.prepareStatement(request.getSql());
+                statement = createStatement(connection, request.getSql());
                 preparedStatementParameter(statement, request.getParameters());
                 statement.execute();
             }
@@ -102,7 +103,7 @@ public abstract class JdbcSqlExecutor {
                             releaseStatement(statement);
                         }
                         printSql(logger, batch);
-                        statement = connection.prepareStatement(batch.getSql());
+                        statement = createStatement(connection, batch.getSql());
                         preparedStatementParameter(statement, batch.getParameters());
                         statement.execute();
                     }
@@ -146,7 +147,7 @@ public abstract class JdbcSqlExecutor {
 
     @SneakyThrows
     protected PreparedStatement createStatement(Connection connection, String sql) {
-        return connection.prepareStatement(sql);
+        return connection.prepareStatement(PostgresqlDriverUtils.escapeJdbcQuestionOperator(connection, sql));
     }
 
     @SneakyThrows

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlDriverUtils.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlDriverUtils.java
@@ -1,5 +1,10 @@
 package org.hswebframework.ezorm.rdb.supports.postgres;
 
+import lombok.SneakyThrows;
+import org.hswebframework.ezorm.rdb.utils.SqlUtils;
+
+import java.sql.Connection;
+
 public final class PostgresqlDriverUtils {
 
     private static final String PG_OBJECT_CLASS = "org.postgresql.util.PGobject";
@@ -9,6 +14,22 @@ public final class PostgresqlDriverUtils {
     private static final String R2DBC_VECTOR_CLASS = "io.r2dbc.postgresql.codec.Vector";
 
     private PostgresqlDriverUtils() {
+    }
+
+    @SneakyThrows
+    public static String escapeJdbcQuestionOperator(Connection connection, String sql) {
+        if (!isPostgresql(connection)) {
+            return sql;
+        }
+        return SqlUtils.escapePostgresqlJdbcQuestionOperator(sql);
+    }
+
+    @SneakyThrows
+    public static boolean isPostgresql(Connection connection) {
+        return connection != null
+            && connection.getMetaData() != null
+            && connection.getMetaData().getDriverName() != null
+            && connection.getMetaData().getDriverName().toLowerCase().contains("postgresql");
     }
 
     public static boolean isPgObject(Object value) {

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlJsonbExistTermFragmentBuilder.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlJsonbExistTermFragmentBuilder.java
@@ -68,18 +68,16 @@ public class PostgresqlJsonbExistTermFragmentBuilder extends AbstractTermFragmen
             return EmptySqlFragments.INSTANCE;
         }
         return new BatchSqlFragments(4, 1)
-            .addSql(operator, "(", columnFullName, ",")
-            .addSql("array[")
+            .addSql(columnFullName, operator, "array[")
             .add(SqlUtils.createQuestionMarks(values.size()))
-            .addSql("])")
+            .addSql("]")
             .addParameter(values);
     }
 
     private static SqlFragments createBaseFragments(String columnFullName, Object value) {
         PrepareSqlFragments fragments = PrepareSqlFragments.of();
-        fragments.addSql(Operator.base, "(", columnFullName, ",");
-        appendPrepareOrNativeValue(fragments, value);
-        return fragments.addSql(")");
+        fragments.addSql(columnFullName, Operator.base);
+        return appendPrepareOrNativeValue(fragments, value);
     }
 
     private static <T extends AppendableSqlFragments> T appendPrepareOrNativeValue(T sql, Object value) {
@@ -164,10 +162,9 @@ public class PostgresqlJsonbExistTermFragmentBuilder extends AbstractTermFragmen
     }
 
     private interface Operator {
-        //用函数规避SimpleParameterList#checkAllParametersSet的检查
-        String base = "jsonb_exists";
-        String all = "jsonb_exists_all";
-        String any = "jsonb_exists_any";
+        String base = "?";
+        String all = "?&";
+        String any = "?|";
         String contains = "@>";
         String contained = "<@";
 

--- a/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/utils/SqlUtils.java
+++ b/hsweb-easy-orm-rdb/src/main/java/org/hswebframework/ezorm/rdb/utils/SqlUtils.java
@@ -284,6 +284,112 @@ public class SqlUtils {
     }
 
     /**
+     * 将 PostgreSQL JSONB ? / ?| / ?& 操作符转义为 PostgreSQL JDBC PreparedStatement 能识别的形式。
+     */
+    public static String escapePostgresqlJdbcQuestionOperator(String sql) {
+        StringBuilder builder = new StringBuilder(sql.length());
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inLineComment = false;
+        boolean inBlockComment = false;
+
+        for (int i = 0; i < sql.length(); i++) {
+            char c = sql.charAt(i);
+
+            if (inLineComment) {
+                builder.append(c);
+                if (c == '\n') {
+                    inLineComment = false;
+                }
+                continue;
+            }
+
+            if (inBlockComment) {
+                builder.append(c);
+                if (c == '*' && i + 1 < sql.length() && sql.charAt(i + 1) == '/') {
+                    builder.append('/');
+                    i++;
+                    inBlockComment = false;
+                }
+                continue;
+            }
+
+            if (!inSingleQuote && !inDoubleQuote) {
+                if (c == '-' && i + 1 < sql.length() && sql.charAt(i + 1) == '-') {
+                    builder.append("--");
+                    i++;
+                    inLineComment = true;
+                    continue;
+                }
+                if (c == '/' && i + 1 < sql.length() && sql.charAt(i + 1) == '*') {
+                    builder.append("/*");
+                    i++;
+                    inBlockComment = true;
+                    continue;
+                }
+            }
+
+            if (!inDoubleQuote && c == '\'') {
+                if (inSingleQuote && i + 1 < sql.length() && sql.charAt(i + 1) == '\'') {
+                    builder.append("''");
+                    i++;
+                    continue;
+                }
+                inSingleQuote = !inSingleQuote;
+                builder.append(c);
+                continue;
+            }
+
+            if (!inSingleQuote && c == '"') {
+                if (inDoubleQuote && i + 1 < sql.length() && sql.charAt(i + 1) == '"') {
+                    builder.append("\"\"");
+                    i++;
+                    continue;
+                }
+                inDoubleQuote = !inDoubleQuote;
+                builder.append(c);
+                continue;
+            }
+
+            if (inSingleQuote || inDoubleQuote) {
+                builder.append(c);
+                continue;
+            }
+
+            if (c == '?') {
+                if (i + 1 < sql.length() && sql.charAt(i + 1) == '?') {
+                    builder.append("??");
+                    i++;
+                    continue;
+                }
+                if (i + 1 < sql.length()) {
+                    char next = sql.charAt(i + 1);
+                    if (next == '|' || next == '&' || next == '!') {
+                        builder.append("??").append(next);
+                        i++;
+                        continue;
+                    }
+                }
+                if (isPostgresOperator(sql, i)) {
+                    builder.append("??");
+                    continue;
+                }
+            }
+
+            builder.append(c);
+        }
+        return builder.toString();
+    }
+
+    private static boolean isPostgresOperatorLeftChar(char prev) {
+        return Character.isLetterOrDigit(prev)
+            || prev == '"'
+            || prev == '_'
+            || prev == ')'
+            || prev == ']';
+    }
+
+    /**
      * 判断当前位置的 '?' 是否是 PostgreSQL 操作符（如 JSONB 的 ? 操作符）
      * <p>
      * PostgreSQL 操作符格式：
@@ -313,11 +419,7 @@ public class SqlUtils {
         char prev = sql.charAt(prevIndex);
         // 标识符字符：字母、数字、下划线、右括号、右方括号、引号
         // 如果不是这些字符，则不是操作符（可能是 =, >, < 等操作符后的参数占位符）
-        if (!(Character.isLetterOrDigit(prev)
-            || prev == '"'
-            || prev == '_'
-            || prev == ')'
-            || prev == ']')) {
+        if (!isPostgresOperatorLeftChar(prev)) {
             return false;
         }
 

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlJsonbExistBuilderCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/supports/postgres/PostgresqlJsonbExistBuilderCoverageTest.java
@@ -25,11 +25,11 @@ public class PostgresqlJsonbExistBuilderCoverageTest {
         RDBColumnMetadata column = jsonbColumn(null);
 
         SqlRequest nativePath = create(column, Term.of("metadata", "exist", NativeSql.of("lower(?)", "name"))).toRequest();
-        Assert.assertEquals("jsonb_exists ( metadata , lower(?) )", nativePath.getSql());
+        Assert.assertEquals("metadata ? lower(?)", nativePath.getSql());
         Assert.assertArrayEquals(new Object[]{"name"}, nativePath.getParameters());
 
         SqlRequest plainPath = create(column, Term.of("metadata", "exist", "profile.name")).toRequest();
-        Assert.assertEquals("jsonb_exists ( metadata , ? )", plainPath.getSql());
+        Assert.assertEquals("metadata ? ?", plainPath.getSql());
         Assert.assertArrayEquals(new Object[]{"profile.name"}, plainPath.getParameters());
     }
 
@@ -38,15 +38,15 @@ public class PostgresqlJsonbExistBuilderCoverageTest {
         RDBColumnMetadata column = jsonbColumn(null);
 
         SqlRequest allFromString = create(column, Term.of("metadata", "exist", "name,age", "all")).toRequest();
-        Assert.assertEquals("jsonb_exists_all ( metadata , array[ ?,? ])", allFromString.getSql());
+        Assert.assertEquals("metadata ?& array[ ?,? ]", allFromString.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "age"}, allFromString.getParameters());
 
         SqlRequest anyFromArray = create(column, Term.of("metadata", "exist", new Object[]{"name", "age"}, "any")).toRequest();
-        Assert.assertEquals("jsonb_exists_any ( metadata , array[ ?,? ])", anyFromArray.getSql());
+        Assert.assertEquals("metadata ?| array[ ?,? ]", anyFromArray.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "age"}, anyFromArray.getParameters());
 
         SqlRequest anyFromCollection = create(column, Term.of("metadata", "exist", Arrays.asList("name", "age"), "any")).toRequest();
-        Assert.assertEquals("jsonb_exists_any ( metadata , array[ ?,? ])", anyFromCollection.getSql());
+        Assert.assertEquals("metadata ?| array[ ?,? ]", anyFromCollection.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "age"}, anyFromCollection.getParameters());
 
         Assert.assertTrue(create(column, Term.of("metadata", "exist", null, "all")).isEmpty());
@@ -112,13 +112,13 @@ public class PostgresqlJsonbExistBuilderCoverageTest {
         SqlRequest in = PostgresqlJsonbTermFragmentBuilder.in
             .createFragments("metadata", column, Term.of("metadata", "in", Arrays.asList("name", "age")))
             .toRequest();
-        Assert.assertEquals("jsonb_exists_any ( metadata , array[ ?,? ])", in.getSql());
+        Assert.assertEquals("metadata ?| array[ ?,? ]", in.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "age"}, in.getParameters());
 
         SqlRequest overlap = PostgresqlJsonbTermFragmentBuilder.overlap
             .createFragments("metadata", column, Term.of("metadata", "overlap", "name,age"))
             .toRequest();
-        Assert.assertEquals("jsonb_exists_any ( metadata , array[ ?,? ])", overlap.getSql());
+        Assert.assertEquals("metadata ?| array[ ?,? ]", overlap.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "age"}, overlap.getParameters());
     }
 
@@ -131,7 +131,7 @@ public class PostgresqlJsonbExistBuilderCoverageTest {
         SqlRequest containsAllKeys = PostgresqlJsonbTermFragmentBuilder.contains
             .createFragments("metadata", column, Term.of("metadata", "contains", Arrays.asList("name", "age"), "all"))
             .toRequest();
-        Assert.assertEquals("jsonb_exists_all ( metadata , array[ ?,? ])", containsAllKeys.getSql());
+        Assert.assertEquals("metadata ?& array[ ?,? ]", containsAllKeys.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "age"}, containsAllKeys.getParameters());
 
         SqlRequest inJsonContains = PostgresqlJsonbTermFragmentBuilder.in
@@ -143,7 +143,7 @@ public class PostgresqlJsonbExistBuilderCoverageTest {
         SqlRequest containsKey = PostgresqlJsonbTermFragmentBuilder.contains
             .createFragments("metadata", column, Term.of("metadata", "contains", "name", "key"))
             .toRequest();
-        Assert.assertEquals("jsonb_exists ( metadata , ? )", containsKey.getSql());
+        Assert.assertEquals("metadata ? ?", containsKey.getSql());
         Assert.assertArrayEquals(new Object[]{"name"}, containsKey.getParameters());
 
         SqlRequest negative = PostgresqlJsonbTermFragmentBuilder.notContains
@@ -172,14 +172,14 @@ public class PostgresqlJsonbExistBuilderCoverageTest {
         containsAll.setColumn("metadata$contains$all");
         containsAll.setValue("name,age");
         SqlRequest containsAllRequest = SimpleTermsFragmentBuilder.createByTable(table, containsAll).toRequest();
-        Assert.assertEquals("jsonb_exists_all ( \"metadata\" , array[ ?,? ])", containsAllRequest.getSql());
+        Assert.assertEquals("\"metadata\" ?& array[ ?,? ]", containsAllRequest.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "age"}, containsAllRequest.getParameters());
 
         Term notOverlap = new Term();
         notOverlap.setColumn("metadata$noverlap");
         notOverlap.setValue(Arrays.asList("name", "status"));
         SqlRequest notOverlapRequest = SimpleTermsFragmentBuilder.createByTable(table, notOverlap).toRequest();
-        Assert.assertEquals("( \"metadata\" is null or not ( jsonb_exists_any ( \"metadata\" , array[ ?,? ]) ) )", notOverlapRequest.getSql());
+        Assert.assertEquals("( \"metadata\" is null or not ( \"metadata\" ?| array[ ?,? ] ) )", notOverlapRequest.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "status"}, notOverlapRequest.getParameters());
     }
 
@@ -192,7 +192,7 @@ public class PostgresqlJsonbExistBuilderCoverageTest {
         columnSyntax.setColumn("metadata$exist$all");
         columnSyntax.setValue("name,age");
         SqlRequest request = create(jsonbColumn(null), columnSyntax).toRequest();
-        Assert.assertEquals("jsonb_exists_all ( metadata , array[ ?,? ])", request.getSql());
+        Assert.assertEquals("metadata ?& array[ ?,? ]", request.getSql());
         Assert.assertArrayEquals(new Object[]{"name", "age"}, request.getParameters());
     }
 

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/SqlUtilsCoverageTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/SqlUtilsCoverageTest.java
@@ -47,6 +47,17 @@ public class SqlUtilsCoverageTest {
     }
 
     @Test
+    public void testEscapePostgresqlJdbcQuestionOperator() {
+        Assert.assertEquals("x ?? 'a'", SqlUtils.escapePostgresqlJdbcQuestionOperator("x ? 'a'"));
+        Assert.assertEquals("x ?? ?", SqlUtils.escapePostgresqlJdbcQuestionOperator("x ? ?"));
+        Assert.assertEquals("x ??| array[?,?]", SqlUtils.escapePostgresqlJdbcQuestionOperator("x ?| array[?,?]"));
+        Assert.assertEquals("x ??& array[?,?]", SqlUtils.escapePostgresqlJdbcQuestionOperator("x ?& array[?,?]"));
+        Assert.assertEquals("x ?? y", SqlUtils.escapePostgresqlJdbcQuestionOperator("x ?? y"));
+        Assert.assertEquals("x '?' ?", SqlUtils.escapePostgresqlJdbcQuestionOperator("x '?' ?"));
+        Assert.assertEquals("x /* ? */ ? 'a'", SqlUtils.escapePostgresqlJdbcQuestionOperator("x /* ? */ ? 'a'"));
+    }
+
+    @Test
     public void testCreateQuestionMarksBoundaryBranches() throws Exception {
         java.lang.reflect.Field field = SqlUtils.class.getDeclaredField("Q_M_CACHE");
         field.setAccessible(true);

--- a/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/SqlUtilsTest.java
+++ b/hsweb-easy-orm-rdb/src/test/java/org/hswebframework/ezorm/rdb/utils/SqlUtilsTest.java
@@ -414,6 +414,7 @@ public class SqlUtilsTest {
         assertEquals("SELECT * FROM user WHERE jsonb_extract_path(data, 'path') ? 'key' AND id = 1", result);
     }
 
+
     // ========== 函数参数预编译测试 ==========
 
     @Test


### PR DESCRIPTION
## 目的

- 将 PostgreSQL JSONB key exists 查询从 `jsonb_exists*` 函数改为 `?` / `?|` / `?&` 操作符。
- 避免 `jsonb_exists_any` 等函数形式无法命中 `jsonb_ops` GIN 索引的问题。
- 保持 SQL builder 输出 PostgreSQL 原生操作符，JDBC 执行链路单独处理 `?` 操作符与预编译占位符冲突。

## 核心变动

- `PostgresqlJsonbExistTermFragmentBuilder`
  - `exist`：生成 `column ? ?`。
  - `all`：生成 `column ?& array[...]`。
  - `any` / `keys` / 通用 `in`、`overlap`：生成 `column ?| array[...]`。
- `JdbcSqlExecutor` / `PostgresqlDriverUtils`
  - 在 JDBC `prepareStatement` 前判断连接是否为 PostgreSQL。
  - 仅 PostgreSQL JDBC 执行链路将 JSONB `?` / `?|` / `?&` 操作符转义为 JDBC 可识别的 `??` / `??|` / `??&`。
  - 日志和 `SqlRequest` 保持原生 PostgreSQL SQL 形态，不污染 R2DBC。
- `SqlUtils`
  - 保留 R2DBC / native SQL 参数替换时跳过 PostgreSQL 原生 JSONB 操作符的能力。
  - 新增 JDBC 专用 PostgreSQL `?` 操作符转义方法，处理字符串、双引号标识符、行注释和块注释。
- 测试
  - 更新 JSONB exists builder 断言为原生 `?` / `?|` / `?&`。
  - 增加 JDBC 专用转义方法的单元测试。
  - 复用现有 PostgreSQL JDBC/R2DBC 集成测试验证真实 SQL 可执行。

## 设计与测试目标

- 设计稿：不适用，本次为已合并 JSONB 查询能力的索引命中修复。
- 用户确认：用户要求确认 R2DBC 能否直接使用 `?|`，并倾向 JDBC 单独处理而不是让 R2DBC 兼容 `??`。
- 测试目标：覆盖 JSONB `?`、`?|`、`?&` 操作符生成、JDBC 执行前转义、R2DBC `$n` 占位符替换和 native SQL 日志还原。
- 数据库兼容与性能：仅 PostgreSQL JSONB 方言；操作符形式可被 PostgreSQL `jsonb_ops` GIN 索引用于 key exists 查询。未做压力测试，本 PR 以 SQL 形态和真实 PostgreSQL 集成执行作为替代验证。
- 注释 / 公共契约：不新增公共 SPI。
- 链路追踪：不涉及业务链路。
- MBean 运维可观测性：不涉及常驻任务、缓存、队列或后台执行器。

## 测试结果

- 命令：`mvn -pl hsweb-easy-orm-rdb -Dtest=PostgresqlJsonbExistBuilderCoverageTest,SqlUtilsCoverageTest,SqlUtilsTest,SqlUtilsBranchTest test`
  - 结果：74 passed, 0 failed, 0 skipped。
- 命令：`mvn -pl hsweb-easy-orm-rdb -Dtest=PostgresqlBasicTest#testJsonbExistTerm test`
  - 结果：1 passed, 0 failed, 0 skipped。
  - Testcontainers：`postgres:11-alpine`。
  - JDBC 日志 SQL 保持原生 `data ? ?`、`data ?| array[ ?,? ]`、`data ?& array[ ?,? ]`；执行前由 JDBC 链路转义。
- 命令：`mvn -pl hsweb-easy-orm-rdb -Dtest=PostgresqlReactiveTests#testJsonbExistTerm test`
  - 结果：1 passed, 0 failed, 0 skipped。
  - Testcontainers：`postgres:11-alpine`。
  - R2DBC SQL 直接使用 `data ? $1`、`data ?| array[ $1,$2 ]`、`data ?& array[ $1,$2 ]`。
- 临时真实库 smoke 验证：
  - JDBC PreparedStatement 直接 `data ?| array[?,?]` 会报“未设定参数值 3”，确认 JDBC 需要转义。
  - R2DBC 直接 `data ?| array[$1,$2]` 和 `data ? $1` 通过，确认不需要 `??`。
- 格式检查：`git diff --check` 通过。

## 文档同步情况

- 未同步长期文档：本次为 PostgreSQL JSONB 查询 SQL 形态和执行链路修复，测试证据放在 PR 描述，不新增任务流水文档。

## 风险与说明

- 影响范围：PostgreSQL JSONB exists 查询、JDBC prepareStatement 前 SQL 转义、`SqlUtils` 参数替换逻辑。
- 方言限制：`?` / `?|` / `?&` 为 PostgreSQL JSONB 操作符，不影响其他数据库方言的 JSON 实现。
- JDBC 说明：仅 PostgreSQL 连接执行前转义 JSONB `?` 操作符，避免 PostgreSQL JDBC 将其误判为预编译占位符。
- R2DBC 说明：R2DBC 直接使用 PostgreSQL 原生 `?` / `?|` / `?&` 操作符，不再依赖 `??` 兼容路径。
